### PR TITLE
[#3] 개발용 staging 서버 구축 및 CI/CD 적용

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,47 @@
+name: backend-cd
+
+on:
+  push:
+    branches: [ "staging" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: pshsh910
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Build and Push Docker image
+        run: |
+          docker build -t pshsh910/tosiltosil:latest --build-arg SPRING_PROFILES_ACTIVE=stag .
+          docker push pshsh910/tosiltosil:latest
+
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to Staging Server
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.LOCAL_SERVER_HOST }}
+          username: ubuntu
+          key: ${{ secrets.LOCAL_SERVER_SSH_KEY }}
+          port: ${{ secrets.LOCAL_SERVER_PORT }}
+          passphrase: ${{ secrets.LOCAL_SERVER_SSH_PASSPHRASE }}
+          script: |
+            echo "✅ Checking if the springboot container is running
+            docker stop springboot || true
+            docker rm springboot || true
+            
+            echo "🏃 Starting the Spring Boot using Docker"
+            docker run --rm -it -d -p 8080:8080 \
+            --name springboot \
+            -e SPRING_PROFILES_ACTIVE=stag \
+            -e spring.config.location=/app/application-stag.yml \
+            -v /home/ubuntu/tosiltosil/application-stag.yml:/app/application-stag.yml \
+            --network web \
+            pshsh910/tosiltosil:latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,5 +36,8 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
 
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+
       - name: Test with Gradle
         run: ./gradlew test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: backend-ci
+
+on:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    services:
+      redis:
+        image: redis:latest
+        ports:
+          - 6379:6379
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'gradle'
+
+      - name: Cache Gradle dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
+
+      - name: Test with Gradle
+        run: ./gradlew test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# gradle build
+FROM gradle:8.13.0-jdk17 AS build
+WORKDIR /app
+COPY . .
+RUN ./gradlew clean bootJar --no-daemon
+
+# image build
+FROM openjdk:17-slim
+WORKDIR /app
+# Copy the built JAR from the build stage
+COPY --from=build /app/build/libs/*.jar app.jar
+ARG SPRING_PROFILES_ACTIVE
+ENV SPRING_PROFILES_ACTIVE $SPRING_PROFILES_ACTIVE
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "app.jar"]


### PR DESCRIPTION
## 🔢 Issue Number
<!-- close #{issue-number} when solved issue -->
close #3 
<!-- relates to #{issue-number} when just link without closing -->

## 👨‍💻 작업 내용
<!-- 회원 비밀번호 저장 암호화 알고리즘을 수정했습니다. --> 
github action을 사용하여 CI 및 staging server CD 만들었습니다.
- 집에 안쓰는 노트북으로 staging server 구축
- gradle test
- Dockerfile을 통한 springboot 이미지 제작

## 🤔 고민할 점
<!-- ERD 설계에서 어떻게 해야할 지 모르겠습니다. -->