### PR TITLE
[#28] SecurityContextHolder에서 Member 정보 추출 기능 추가

### DIFF
--- a/src/main/java/tosiltosil/backend/common/auth/AuthDetails.java
+++ b/src/main/java/tosiltosil/backend/common/auth/AuthDetails.java
@@ -15,6 +15,10 @@ public class AuthDetails implements UserDetails {
 
     private final UUID memberId;
 
+    public UUID getMemberId() {
+        return memberId;
+    }
+
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         return Collections.emptyList();

--- a/src/main/java/tosiltosil/backend/common/auth/annotation/LoginMember.java
+++ b/src/main/java/tosiltosil/backend/common/auth/annotation/LoginMember.java
@@ -1,0 +1,11 @@
+package tosiltosil.backend.common.auth.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LoginMember {
+}

--- a/src/main/java/tosiltosil/backend/common/auth/filter/JwtAuthFilter.java
+++ b/src/main/java/tosiltosil/backend/common/auth/filter/JwtAuthFilter.java
@@ -6,6 +6,7 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -29,8 +30,11 @@ public class JwtAuthFilter extends OncePerRequestFilter {
     private final JwtTokenProvider jwtTokenProvider;
     private final CookieUtil cookieUtil;
 
-    private static final String ACCESS_TOKEN_COOKIE_NAME = "access_token";
-    private static final String REFRESH_TOKEN_COOKIE_NAME = "refresh_token";
+    @Value("${jwt.cookie.name.access}")
+    private String ACCESS_TOKEN_COOKIE_NAME;
+
+    @Value("${jwt.cookie.name.refresh}")
+    private String REFRESH_TOKEN_COOKIE_NAME;
 
     @Override
     protected void doFilterInternal(

--- a/src/main/java/tosiltosil/backend/common/auth/resolver/LoginMemberArgumentResolver.java
+++ b/src/main/java/tosiltosil/backend/common/auth/resolver/LoginMemberArgumentResolver.java
@@ -1,0 +1,43 @@
+package tosiltosil.backend.common.auth.resolver;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+import tosiltosil.backend.common.auth.AuthDetails;
+import tosiltosil.backend.common.auth.annotation.LoginMember;
+import tosiltosil.backend.common.domain.exception.UnauthorizedException;
+
+import java.util.UUID;
+
+@Component
+public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(LoginMember.class)
+                && parameter.getParameterType().equals(UUID.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+            NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || !authentication.isAuthenticated()) {
+            throw new UnauthorizedException("로그인이 필요합니다.");
+        }
+
+        Object principal = authentication.getPrincipal();
+
+        if(!(principal instanceof AuthDetails authDetails)) {
+            throw new UnauthorizedException("인증 정보가 올바르지 않습니다.");
+        }
+
+        return authDetails.getMemberId();
+    }
+}

--- a/src/main/java/tosiltosil/backend/common/web/config/WebConfig.java
+++ b/src/main/java/tosiltosil/backend/common/web/config/WebConfig.java
@@ -1,0 +1,22 @@
+package tosiltosil.backend.common.web.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import tosiltosil.backend.common.auth.resolver.LoginMemberArgumentResolver;
+import java.util.List;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    private final LoginMemberArgumentResolver loginMemberArgumentResolver;
+
+    public WebConfig(LoginMemberArgumentResolver loginMemberArgumentResolver) {
+        this.loginMemberArgumentResolver = loginMemberArgumentResolver;
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(loginMemberArgumentResolver);
+    }
+}


### PR DESCRIPTION
## 🔢 Issue Number
close #28

## 👨‍💻 작업 내용
1️⃣ `@LoginMember` 어노테이션과 LoginMemberArgumentResolver를 추가하여, 어노테이션을 통해 로그인한 사용자의 id를 Controller로 넘길 수 있도록 구현했습니다.

Controller에서 다음과 같이 작성하여 사용할 수 있습니다.

``` java
@GetMapping("/me")
public Response<ProfileDto> getMyProfile(@LoginMember final UUID memberId) {
    ProfileDto profileDto = memberService.getMyProfile(memberId);
    return Response.ok("나의 정보를 조회했습니다.", profileDto);
}
```

2️⃣ WebConfig를 생성하여 Resolver를 Spring MVC에 등록하도록 했습니다.

😵‍💫 JwtAuthFilter에 잘못된 Cookie 이름 설정으로 인한 오류가 있어, yml 파일에서 받아오도록 수정했습니다.


## 🤔 고민할 점


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 컨트롤러 메서드에서 `@LoginMember` 어노테이션을 통해 로그인된 회원의 ID를 자동으로 주입받을 수 있는 기능이 추가되었습니다.
  * 인증 관련 설정을 외부 환경설정 파일에서 동적으로 지정할 수 있도록 개선되었습니다.

* **버그 수정**
  * 인증 정보가 없거나 올바르지 않은 경우 명확한 예외 메시지로 처리됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->