### PR TITLE
[#36] REST Docs 문서 표시

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -113,11 +113,11 @@ asciidoctor {
 
 tasks.register('copyDocument', Copy) {
     dependsOn asciidoctor
-    delete('src/main/resources/static/docs')
     from("${asciidoctor.outputDir}") {
         include("**/index.html")
     }
     into('src/main/resources/static/docs')
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
 }
 
 bootJar {

--- a/src/main/java/tosiltosil/backend/common/auth/config/SecurityConfig.java
+++ b/src/main/java/tosiltosil/backend/common/auth/config/SecurityConfig.java
@@ -43,6 +43,8 @@ public class SecurityConfig {
                         .requestMatchers("/api/v1/auth/reissue").permitAll()
                         // swagger
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                        // restdocs
+                        .requestMatchers("/docs/**").permitAll()
                         // h2
                         .requestMatchers("/h2-console/**").permitAll()
                         .anyRequest().authenticated())

--- a/src/main/java/tosiltosil/backend/common/web/config/WebConfig.java
+++ b/src/main/java/tosiltosil/backend/common/web/config/WebConfig.java
@@ -19,4 +19,10 @@ public class WebConfig implements WebMvcConfigurer {
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(loginMemberArgumentResolver);
     }
+
+    @Override
+    public void addResourceHandlers(org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry registry) {
+        registry.addResourceHandler("/docs/**")
+                .addResourceLocations("classpath:/static/docs/");
+    }
 }


### PR DESCRIPTION
## 🔢 Issue Number
<!-- close #{issue-number} when solved issue -->
<!-- relates to #{issue-number} when just link without closing -->
close #36 

## 👨‍💻 작업 내용
<!-- 회원 비밀번호 저장 암호화 알고리즘을 수정했습니다. --> 
### REST Docs 리소스를 접근할 수 있도록 리소스 요청을 허용했습니다.

1. `/src/main/resources/static/docs/` 안에 `index.html` 파일 생성
2. `localhost:8080/docs/index.html`로 접근 가능!

## 🤔 고민할 점
<!-- ERD 설계에서 어떻게 해야할 지 모르겠습니다. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * "/docs/**" 경로로 접근 시 정적 문서 리소스를 인증 없이 확인할 수 있도록 지원합니다.
  * "/docs/**" URL 패턴에 대한 정적 리소스 제공이 추가되었습니다.

* **버그 수정**
  * 문서 복사 과정에서 중복 파일이 포함될 수 있도록 처리 방식을 개선하였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->