### PR TITLE
[#38] 카테고리 날짜 별 카테고리 색깔 조회 메서드 쿼리 수정

### DIFF
--- a/src/main/java/tosiltosil/backend/module/category/infrastructure/CategoryDslRepository.java
+++ b/src/main/java/tosiltosil/backend/module/category/infrastructure/CategoryDslRepository.java
@@ -1,14 +1,18 @@
 package tosiltosil.backend.module.category.infrastructure;
 
-import static com.querydsl.core.types.Projections.list;
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.mapping;
+import static java.util.stream.Collectors.toList;
 import static tosiltosil.backend.module.category.domain.QCategory.category;
 import static tosiltosil.backend.module.goal.domain.QGoal.goal;
 
-import com.querydsl.core.group.GroupBy;
-import com.querydsl.core.types.Projections;
+import com.querydsl.core.Tuple;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDate;
 import java.time.YearMonth;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -24,20 +28,37 @@ public class CategoryDslRepository {
             final UUID memberId,
             final YearMonth yearMonth
     ) {
-        return queryFactory
+        // 1. 날짜 별 카테고리 색깔 모두 조회
+        List<Tuple> fetch = queryFactory
+                .selectDistinct(goal.date, category.color)
                 .from(goal)
                 .join(category)
                 .on(goal.categoryId.eq(category.id))
                 .where(
                         goal.memberId.eq(memberId),
                         goal.date.between(yearMonth.atDay(1), yearMonth.atEndOfMonth())
+                        // TODO: 순서 조건 추가 및 목표 완료 상태 조건 추가
                 )
-                .orderBy(goal.date.asc(), category.color.asc()) // 순서
-                .transform(GroupBy.groupBy(goal.date).list(
-                        Projections.constructor(CategoryColorPerDayResponse.class,
-                                goal.date,
-                                list(category.color)
+                .orderBy(goal.date.asc(), category.color.asc())
+                .fetch();
+
+        // 2. 날짜 별 색깔 grouping
+        Map<LocalDate, List<String>> grouping = fetch
+                .stream()
+                .collect(groupingBy(
+                        tuple -> Objects.requireNonNull(tuple.get(goal.date)),
+                        mapping(
+                                tuple -> Objects.requireNonNull(tuple.get(category.color)),
+                                toList()
                         )
                 ));
+
+        // 3. 색깔 2개 제한 stream 적용
+        return grouping.entrySet().stream()
+                .map(entry -> new CategoryColorPerDayResponse(
+                        entry.getKey(),
+                        entry.getValue().stream().limit(2).collect(toList())
+                ))
+                .collect(toList());
     }
 }

--- a/src/main/java/tosiltosil/backend/module/category/infrastructure/CategoryDslRepository.java
+++ b/src/main/java/tosiltosil/backend/module/category/infrastructure/CategoryDslRepository.java
@@ -10,6 +10,7 @@ import com.querydsl.core.Tuple;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDate;
 import java.time.YearMonth;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -47,6 +48,7 @@ public class CategoryDslRepository {
                 .stream()
                 .collect(groupingBy(
                         tuple -> Objects.requireNonNull(tuple.get(goal.date)),
+                        LinkedHashMap::new,
                         mapping(
                                 tuple -> Objects.requireNonNull(tuple.get(category.color)),
                                 toList()


### PR DESCRIPTION
## 🔢 Issue Number
<!-- close #{issue-number} when solved issue -->
<!-- relates to #{issue-number} when just link without closing -->
close #38 

## 👨‍💻 작업 내용
<!-- 회원 비밀번호 저장 암호화 알고리즘을 수정했습니다. --> 
### 쿼리 수정
SQL level에서 갯수를 따로 처리하기엔 쿼리가 너무 복잡했습니다.

그래서 대신 application level에서 해결하고자 `Java Collectors API`를 활용했습니다.

정상 작동합니다 :)

## 🤔 고민할 점
<!-- ERD 설계에서 어떻게 해야할 지 모르겠습니다. -->
추후에 더 개선할 점이 있는지 살펴 볼 필요가 있습니다 :)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **리팩터링**
  * 월별 카테고리 색상 조회 방식이 개선되어, 데이터 그룹화와 매핑 과정이 더욱 안정적으로 처리됩니다.  
  * 기능 동작에는 변화가 없으며, 사용자 경험에는 영향이 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->