### PR TITLE
[#40] REST Docs 문서 접근 불가 이슈 해결

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,7 +2,7 @@ name: backend-cd
 
 on:
   push:
-    branches: [ "develop", "hotfix" ]
+    branches: [ "develop", "hotfix/#40-docs" ]
 
 jobs:
   build:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,7 +2,7 @@ name: backend-cd
 
 on:
   push:
-    branches: [ "develop", "hotfix/#40-docs" ]
+    branches: [ "develop" ]
 
 jobs:
   build:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,7 +2,7 @@ name: backend-cd
 
 on:
   push:
-    branches: [ "develop" ]
+    branches: [ "develop", "hotfix" ]
 
 jobs:
   build:

--- a/build.gradle
+++ b/build.gradle
@@ -111,15 +111,9 @@ asciidoctor {
     baseDirFollowsSourceFile()
 }
 
-tasks.register('copyDocument', Copy) {
+bootJar {
     dependsOn asciidoctor
     from("${asciidoctor.outputDir}") {
-        include("**/index.html")
+        into 'static/docs'
     }
-    into('src/main/resources/static/docs')
-    duplicatesStrategy = DuplicatesStrategy.INCLUDE
-}
-
-bootJar {
-    dependsOn copyDocument
 }

--- a/build.gradle
+++ b/build.gradle
@@ -121,6 +121,5 @@ tasks.register('copyDocument', Copy) {
 }
 
 bootJar {
-    dependsOn asciidoctor
     dependsOn copyDocument
 }

--- a/src/main/java/tosiltosil/backend/common/web/config/WebConfig.java
+++ b/src/main/java/tosiltosil/backend/common/web/config/WebConfig.java
@@ -23,6 +23,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addResourceHandlers(org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry registry) {
         registry.addResourceHandler("/docs/**")
-                .addResourceLocations("classpath:/static/docs/");
+                .addResourceLocations("classpath:/static/docs/")
+                .setCachePeriod(20);
     }
 }


### PR DESCRIPTION
## 🔢 Issue Number
<!-- close #{issue-number} when solved issue -->
<!-- relates to #{issue-number} when just link without closing -->
close #40 

## 👨‍💻 작업 내용
<!-- 회원 비밀번호 저장 암호화 알고리즘을 수정했습니다. --> 
### gradle 스크립트 수정
- 기존에 `src/` 내에서 볼 수 있도록 copyDocument task를 추가했지만, gradle bootJar 시 `index.html` 파일이 `.jar` 내에 추가되지 않는 문제가 발생했습니다.
- 그래서 [공식 문서](https://docs.spring.io/spring-restdocs/docs/current/reference/htmlsingle/#getting-started-build-configuration-packaging-the-documentation)에 나온 대로 gradle 스크립트를 재수정했습니다 :)

## 🤔 고민할 점
<!-- ERD 설계에서 어떻게 해야할 지 모르겠습니다. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **기능 개선**
  * 정적 문서 리소스("/docs/**")에 대해 20초간 캐시가 적용되어 더 빠른 접근이 가능합니다.

* **빌드/배포**
  * 문서 파일이 jar 내부의 static/docs 경로에 전체 포함되어 배포가 간소화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->