### PR TITLE
[#48] 목표 상태 한글 조회

### DIFF
--- a/src/main/java/tosiltosil/backend/module/goal/domain/response/DayGoalListResponse.java
+++ b/src/main/java/tosiltosil/backend/module/goal/domain/response/DayGoalListResponse.java
@@ -1,6 +1,7 @@
 package tosiltosil.backend.module.goal.domain.response;
 
 import java.util.List;
+import tosiltosil.backend.module.goal.domain.value.GoalStatus;
 
 public record DayGoalListResponse(
         Long categoryId,
@@ -15,7 +16,7 @@ public record DayGoalListResponse(
             //Long order,
             Long iconId,
             String title,
-            String status,
+            GoalStatus status,
             String totalTime,
             String duration
     ) {

--- a/src/main/java/tosiltosil/backend/module/goal/domain/value/GoalStatus.java
+++ b/src/main/java/tosiltosil/backend/module/goal/domain/value/GoalStatus.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 public enum GoalStatus {
     BEFORE_STARTING("시작 전"),
     RUNNING("진행 중"),
-    PAUSED("일시 정지"),
+    PAUSED("진행 중"),
     COMPLETED("완료"),
     FAILED("실패");
 

--- a/src/main/java/tosiltosil/backend/module/goal/domain/value/GoalStatus.java
+++ b/src/main/java/tosiltosil/backend/module/goal/domain/value/GoalStatus.java
@@ -1,9 +1,22 @@
 package tosiltosil.backend.module.goal.domain.value;
 
+import com.fasterxml.jackson.annotation.JsonValue;
+
 public enum GoalStatus {
-    BEFORE_STARTING,
-    RUNNING,
-    PAUSED,
-    COMPLETED,
-    FAILED
+    BEFORE_STARTING("시작 전"),
+    RUNNING("진행 중"),
+    PAUSED("일시 정지"),
+    COMPLETED("완료"),
+    FAILED("실패");
+
+    private final String koreanName;
+
+    GoalStatus(final String koreanName) {
+        this.koreanName = koreanName;
+    }
+
+    @JsonValue
+    public String getKoreanName() {
+        return koreanName;
+    }
 }

--- a/src/main/java/tosiltosil/backend/module/goal/infrastructure/GoalDslRepository.java
+++ b/src/main/java/tosiltosil/backend/module/goal/infrastructure/GoalDslRepository.java
@@ -45,7 +45,7 @@ public class GoalDslRepository {
                                                 category.id,
                                                 goal.iconId,
                                                 goal.title,
-                                                goal.status.stringValue(),
+                                                goal.status,
                                                 // ISO-8601 Duration 문자열(예: "PT2H")로 응답하기 위해 SQL에서 VARCHAR로 캐스팅
                                                 Expressions.stringTemplate("CAST({0} AS VARCHAR)", goal.totalTime),
                                                 Expressions.stringTemplate("CAST({0} AS VARCHAR)", goal.duration)

--- a/src/test/java/tosiltosil/backend/module/goal/presentation/GoalControllerRestDocsTest.java
+++ b/src/test/java/tosiltosil/backend/module/goal/presentation/GoalControllerRestDocsTest.java
@@ -25,6 +25,7 @@ import tosiltosil.backend.module.goal.domain.request.GoalUpdateRequest;
 import tosiltosil.backend.module.goal.domain.response.DayGoalListResponse;
 import tosiltosil.backend.module.goal.domain.response.GoalIdResponse;
 import tosiltosil.backend.module.goal.domain.response.GoalIdsResponse;
+import tosiltosil.backend.module.goal.domain.value.GoalStatus;
 import tosiltosil.backend.module.stopwatch.application.StopwatchService;
 import tosiltosil.backend.support.RestDocsTestSupport;
 
@@ -48,11 +49,11 @@ class GoalControllerRestDocsTest extends RestDocsTestSupport {
         
         List<DayGoalListResponse> responses = List.of(
                 new DayGoalListResponse(1L, "운동", "#FF5733", List.of(
-                        new DayGoalListResponse.GoalListResponse(1L, 1L, 1L, "운동하기", "BEFORE_STARTING", "PT2H", "PT0S"),
-                        new DayGoalListResponse.GoalListResponse(2L, 1L, 2L, "독서하기", "RUNNING", "PT1H30M", "PT30M")
+                        new DayGoalListResponse.GoalListResponse(1L, 1L, 1L, "운동하기", GoalStatus.BEFORE_STARTING, "PT2H", "PT0S"),
+                        new DayGoalListResponse.GoalListResponse(2L, 1L, 2L, "독서하기", GoalStatus.RUNNING, "PT1H30M", "PT30M")
                 )),
                 new DayGoalListResponse(2L, "공부", "#33C3F0", List.of(
-                        new DayGoalListResponse.GoalListResponse(3L, 2L, 3L, "코딩하기", "PAUSED", "PT3H", "PT1H15M")
+                        new DayGoalListResponse.GoalListResponse(3L, 2L, 3L, "코딩하기", GoalStatus.RUNNING, "PT3H", "PT1H15M")
                 ))
         );
 
@@ -82,7 +83,7 @@ class GoalControllerRestDocsTest extends RestDocsTestSupport {
                                                 "categoryId": 1,
                                                 "iconId": 1,
                                                 "title": "운동하기",
-                                                "status": "BEFORE_STARTING",
+                                                "status": "시작 전",
                                                 "totalTime": "PT2H",
                                                 "duration": "PT0S"
                                             },
@@ -91,7 +92,7 @@ class GoalControllerRestDocsTest extends RestDocsTestSupport {
                                                 "categoryId": 1,
                                                 "iconId": 2,
                                                 "title": "독서하기",
-                                                "status": "RUNNING",
+                                                "status": "진행 중",
                                                 "totalTime": "PT1H30M",
                                                 "duration": "PT30M"
                                             }
@@ -107,7 +108,7 @@ class GoalControllerRestDocsTest extends RestDocsTestSupport {
                                                 "categoryId": 2,
                                                 "iconId": 3,
                                                 "title": "코딩하기",
-                                                "status": "PAUSED",
+                                                "status": "진행 중",
                                                 "totalTime": "PT3H",
                                                 "duration": "PT1H15M"
                                             }
@@ -137,7 +138,7 @@ class GoalControllerRestDocsTest extends RestDocsTestSupport {
                                 responseField("data[].goals[].categoryId", JsonFieldType.NUMBER, "카테고리 ID", "1"),
                                 responseField("data[].goals[].iconId", JsonFieldType.NUMBER, "아이콘 ID", "1"),
                                 responseField("data[].goals[].title", JsonFieldType.STRING, "목표 제목", "운동하기"),
-                                responseField("data[].goals[].status", JsonFieldType.STRING, "목표 상태 (BEFORE_STARTING, RUNNING, PAUSED, COMPLETED, FAILED)", "BEFORE_STARTING"),
+                                responseField("data[].goals[].status", JsonFieldType.STRING, "목표 상태 (시작 전, 진행 중, 완료, 실패)", "시작 전"),
                                 responseField("data[].goals[].totalTime", JsonFieldType.STRING, "목표 총 시간 (ISO-8601 Duration 형식)", "PT2H"),
                                 responseField("data[].goals[].duration", JsonFieldType.STRING, "현재까지 진행된 시간 (ISO-8601 Duration 형식)", "PT0S")
                         )


### PR DESCRIPTION
## 🔢 Issue Number
<!-- close #{issue-number} when solved issue -->
<!-- relates to #{issue-number} when just link without closing -->
close #48 

## 👨‍💻 작업 내용
<!-- 회원 비밀번호 저장 암호화 알고리즘을 수정했습니다. --> 
### 목표 상태 조회 한글화
목표 상태를 한글로 조회할 수 있도록 Enum 클래스에 `@JsonValue`를 추가했습니다.

### 목표 PAUSED 상태
비즈니스 규칙(화면 표시) 상 "일시 정지"가 아닌 "진행 중"으로 바꿔서 표시하도록 변경했습니다. 

## 🤔 고민할 점
<!-- ERD 설계에서 어떻게 해야할 지 모르겠습니다. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 목표 상태가 한글로 표시되어 사용자에게 더 직관적으로 제공됩니다.

* **버그 수정**
  * 목표 상태 관련 API 응답 및 문서가 실제 반환되는 한글 상태값과 일치하도록 개선되었습니다.

* **테스트**
  * 테스트 코드와 기대 응답이 한글 상태값을 반영하도록 수정되었습니다.

* **문서화**
  * API 문서 내 목표 상태 설명이 한글 상태값으로 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->