### PR TITLE
[#53] 필수 쿠키 누락 예외 처리 추가

### DIFF
--- a/src/main/java/tosiltosil/backend/common/web/handler/GlobalExceptionHandler.java
+++ b/src/main/java/tosiltosil/backend/common/web/handler/GlobalExceptionHandler.java
@@ -106,7 +106,7 @@ public class GlobalExceptionHandler {
         ErrorDetailResponse errorDetailResponse = ErrorDetailResponse.of(
                 e.getCookieName(),
                 null,
-                e.getMessage()
+                "쿠키가 존재하지 않습니다."
         );
 
         InfoLog infoLog = InfoLog.of(e.getCookieName() + " 필수 쿠키 누락으로 실패");

--- a/src/main/java/tosiltosil/backend/common/web/handler/GlobalExceptionHandler.java
+++ b/src/main/java/tosiltosil/backend/common/web/handler/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestCookieException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -91,6 +92,29 @@ public class GlobalExceptionHandler {
         return ErrorResponse.of(
                 400,
                 "파라미터가 누락되었습니다",
+                List.of(errorDetailResponse)
+        );
+    }
+
+    /**
+     *  쿠키 누락 예외 처리
+     *  - 필수 요청 cookie가 누락되었을 경우 발생
+     */
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(MissingRequestCookieException.class)
+    public ErrorResponse handleMissingRequestCookieException(MissingRequestCookieException e) {
+        ErrorDetailResponse errorDetailResponse = ErrorDetailResponse.of(
+                e.getCookieName(),
+                null,
+                e.getMessage()
+        );
+
+        InfoLog infoLog = InfoLog.of(e.getCookieName() + " 필수 쿠키 누락으로 실패");
+        infoLog.writeLog();
+
+        return ErrorResponse.of(
+                400,
+                "필수 쿠키가 누락되었습니다.",
                 List.of(errorDetailResponse)
         );
     }


### PR DESCRIPTION
## 🔢 Issue Number
close #53

## 👨‍💻 작업 내용
필수 쿠키가 누락되었을 때, 400 예외처리를 할 수 있도록 GlobalExceptionHandler에 예외 처리 로직을 추가했습니다.

예외처리 응답 예시는 다음과 같습니다.
``` json
{
    "status": 400,
    "message": "필수 쿠키가 누락되었습니다.",
    "errors": [
        {
            "field": "client-id",
            "value": null,
            "reason": "쿠키가 존재하지 않습니다."
        }
    ]
}
```

## 🤔 고민할 점
지금은 코드의 통일성을 위해 errors.reason을 `e.getMessage()`로 작성했습니다.
하지만 다른 예외 응답에서는 reason을 한국어로 작성해왔기 때문에 이렇게 유지해도 괜찮을지 고민됩니다..!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 필수 쿠키가 누락된 요청에 대해 명확한 오류 메시지와 함께 400 오류가 반환되도록 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->