### PR TITLE
[#58] 스탑워치 완료 및 스탑워치 활성화 로직 구현

### DIFF
--- a/src/docs/asciidoc/stopwatch.adoc
+++ b/src/docs/asciidoc/stopwatch.adoc
@@ -31,6 +31,8 @@ include::{snippets}/stopwatch-controller-rest-docs-test/스톱워치_시작_시_
 
 === 스톱워치 정지
 
+！ 스톱워치를 완료했을 경우, 별도로 완료 API가 존재하지 않고 정지 API를 사용합니다.
+
 ==== Request
 
 include::{snippets}/stopwatch-controller-rest-docs-test/스톱워치_정지하기/http-request.adoc[]

--- a/src/main/java/tosiltosil/backend/module/goal/application/GoalEventHandler.java
+++ b/src/main/java/tosiltosil/backend/module/goal/application/GoalEventHandler.java
@@ -23,5 +23,8 @@ public class GoalEventHandler {
 
         Duration addedDuration = Duration.between(event.startTime(), event.endTime());
         goal.addDuration(addedDuration);
+
+        // 목표 완료되었는지 체크 및 반영
+        goal.changeStatusToCompleted();
     }
 }

--- a/src/main/java/tosiltosil/backend/module/goal/domain/Goal.java
+++ b/src/main/java/tosiltosil/backend/module/goal/domain/Goal.java
@@ -123,6 +123,7 @@ public class Goal extends BaseEntity implements Orderable {
         }
     }
 
+    // basic info
     public void updateBasicInfo(
             final String title,
             final Long categoryId,
@@ -137,26 +138,51 @@ public class Goal extends BaseEntity implements Orderable {
         this.date = date;
     }
 
+    // status
     public void changeStatusToStarted() {
-        if (this.status == GoalStatus.BEFORE_STARTING || this.status == GoalStatus.PAUSED) {
-            this.status = GoalStatus.RUNNING;
-        } else {
-            throw new ConflictException("스톱워치가 이미 실행되거나 기간이 지난 상태입니다.");
-        }
+        validateNotCompleted();
+        validateNotFailed();
+        validateNotRunning();
+        this.status = GoalStatus.RUNNING;
     }
 
     public void changeStatusToPaused() {
+        validateNotCompleted();
+        validateNotFailed();
+        validateNotPaused();
+        this.status = GoalStatus.PAUSED;
+    }
+
+    private void validateNotCompleted() {
+        if (this.status == GoalStatus.COMPLETED) {
+            throw new ConflictException("이미 완료된 목표입니다.");
+        }
+    }
+
+    private void validateNotFailed() {
+        if (this.status == GoalStatus.FAILED) {
+            throw new ConflictException("기간이 지나 실패한 목표입니다.");
+        }
+    }
+
+    private void validateNotRunning() {
         if (this.status == GoalStatus.RUNNING) {
-            this.status = GoalStatus.PAUSED;
-        } else {
+            throw new ConflictException("스톱워치가 이미 실행중입니다.");
+        }
+    }
+
+    private void validateNotPaused() {
+        if (this.status == GoalStatus.BEFORE_STARTING || this.status == GoalStatus.PAUSED) {
             throw new ConflictException("스톱워치가 이미 정지되었습니다.");
         }
     }
 
+    // duration
     public void addDuration(final Duration addedDuration) {
         this.duration = this.duration.plus(addedDuration);
     }
 
+    // order index
     public void updateOrderIndex(final BigDecimal orderIndex) {
         this.orderIndex = orderIndex;
     }

--- a/src/main/java/tosiltosil/backend/module/goal/domain/Goal.java
+++ b/src/main/java/tosiltosil/backend/module/goal/domain/Goal.java
@@ -153,6 +153,12 @@ public class Goal extends BaseEntity implements Orderable {
         this.status = GoalStatus.PAUSED;
     }
 
+    public void changeStatusToCompleted() {
+        if (this.duration.compareTo(this.totalTime) >= 0) {
+            this.status = GoalStatus.COMPLETED;
+        }
+    }
+
     private void validateNotCompleted() {
         if (this.status == GoalStatus.COMPLETED) {
             throw new ConflictException("이미 완료된 목표입니다.");

--- a/src/main/java/tosiltosil/backend/module/member/domain/Member.java
+++ b/src/main/java/tosiltosil/backend/module/member/domain/Member.java
@@ -7,7 +7,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import tosiltosil.backend.common.domain.BaseEntity;
 import tosiltosil.backend.module.member.domain.value.LoginType;
-import tosiltosil.backend.module.member.domain.value.StopwatchStatus;
 
 import java.util.UUID;
 
@@ -40,10 +39,6 @@ public class Member extends BaseEntity {
     @Column(nullable = false)
     private boolean visibility;
 
-    @Column(nullable = false)
-    @Enumerated(EnumType.STRING)
-    private StopwatchStatus stopwatchStatus;
-
     @Builder
     private Member(
             final String nickname,
@@ -51,8 +46,7 @@ public class Member extends BaseEntity {
             final String profileImageUrl,
             final LoginType loginType,
             final String email,
-            final boolean visibility,
-            final StopwatchStatus stopwatchStatus
+            final boolean visibility
     ) {
         this.nickname = nickname;
         this.code = code;
@@ -60,7 +54,6 @@ public class Member extends BaseEntity {
         this.loginType = loginType;
         this.email = email;
         this.visibility = visibility;
-        this.stopwatchStatus = stopwatchStatus;
     }
 
     public static Member of(
@@ -77,7 +70,6 @@ public class Member extends BaseEntity {
                 .loginType(loginType)
                 .email(email)
                 .visibility(true)
-                .stopwatchStatus(StopwatchStatus.INACTIVE)
                 .build();
     }
 }

--- a/src/main/java/tosiltosil/backend/module/stopwatch/application/StopwatchService.java
+++ b/src/main/java/tosiltosil/backend/module/stopwatch/application/StopwatchService.java
@@ -3,6 +3,7 @@ package tosiltosil.backend.module.stopwatch.application;
 import java.time.Duration;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import tosiltosil.backend.common.domain.exception.NotFoundException;
@@ -10,10 +11,12 @@ import tosiltosil.backend.common.messaging.Events;
 import tosiltosil.backend.module.duration.application.DurationService;
 import tosiltosil.backend.module.goal.application.GoalService;
 import tosiltosil.backend.module.stopwatch.domain.Stopwatch;
+import tosiltosil.backend.module.stopwatch.domain.StopwatchActivity;
 import tosiltosil.backend.module.stopwatch.domain.StopwatchRepository;
 import tosiltosil.backend.module.stopwatch.domain.event.StopwatchPausedEvent;
 import tosiltosil.backend.module.stopwatch.domain.event.StopwatchStartedEvent;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -37,6 +40,13 @@ public class StopwatchService {
         // 오늘 총 진행 시간 가져오기 - 방금 시작된 스톱워치 시간은 제외
         Duration todayDuration = durationService.getTodayDuration(memberId);
 
+        // 사용자 스탑워치 활성 상태로 변경
+        stopwatchRepository.findStopwatchActivityByMemberId(memberId)
+                .ifPresentOrElse(
+                        StopwatchActivity::changeToActive,
+                        () -> log.warn("사용자의 Stopwatch Activity 데이터가 존재하지 않습니다. memberId: {}", memberId)
+                );
+
         // 스탑워치 시작 메세지 전송
         Events.raise(
                 StopwatchStartedEvent.of(memberId, stopwatch, todayDuration)
@@ -57,6 +67,13 @@ public class StopwatchService {
 
         // 오늘 총 진행 시간 업데이트
         Duration updatedTodayDuration = durationService.updateTodayDuration(memberId, stopwatch.getDuration());
+
+        // 사용자 스탑워치 비활성 상태로 변경
+        stopwatchRepository.findStopwatchActivityByMemberId(memberId)
+                .ifPresentOrElse(
+                        StopwatchActivity::changeToInactive,
+                        () -> log.warn("사용자의 Stopwatch Activity 데이터가 존재하지 않습니다. memberId: {}", memberId)
+                );
 
         // 스탑워치 정지 메세지 전송 + 목표 진행 시간 업데이트
         Events.raise(

--- a/src/main/java/tosiltosil/backend/module/stopwatch/application/StopwatchService.java
+++ b/src/main/java/tosiltosil/backend/module/stopwatch/application/StopwatchService.java
@@ -41,11 +41,13 @@ public class StopwatchService {
         Duration todayDuration = durationService.getTodayDuration(memberId);
 
         // 사용자 스탑워치 활성 상태로 변경
-        stopwatchRepository.findStopwatchActivityByMemberId(memberId)
-                .ifPresentOrElse(
-                        StopwatchActivity::changeToActive,
-                        () -> log.warn("사용자의 Stopwatch Activity 데이터가 존재하지 않습니다. memberId: {}", memberId)
-                );
+        StopwatchActivity stopwatchActivity = stopwatchRepository.findStopwatchActivityByMemberId(memberId)
+                .orElseGet(() -> {
+                    log.warn("사용자의 Stopwatch Activity 데이터가 존재하지 않아 자동 생성합니다. 회원가입이 정상적으로 이루어졌는지 확인해주세요");
+                    return StopwatchActivity.of(memberId);
+                });
+        stopwatchActivity.changeToActive();
+        stopwatchRepository.saveStopwatchActivity(stopwatchActivity);
 
         // 스탑워치 시작 메세지 전송
         Events.raise(
@@ -69,11 +71,13 @@ public class StopwatchService {
         Duration updatedTodayDuration = durationService.updateTodayDuration(memberId, stopwatch.getDuration());
 
         // 사용자 스탑워치 비활성 상태로 변경
-        stopwatchRepository.findStopwatchActivityByMemberId(memberId)
-                .ifPresentOrElse(
-                        StopwatchActivity::changeToInactive,
-                        () -> log.warn("사용자의 Stopwatch Activity 데이터가 존재하지 않습니다. memberId: {}", memberId)
-                );
+        StopwatchActivity stopwatchActivity = stopwatchRepository.findStopwatchActivityByMemberId(memberId)
+                .orElseGet(() -> {
+                    log.warn("사용자의 Stopwatch Activity 데이터가 존재하지 않아 자동 생성합니다. 회원가입이 정상적으로 이루어졌는지 확인해주세요");
+                    return StopwatchActivity.of(memberId);
+                });
+        stopwatchActivity.changeToInactive();
+        stopwatchRepository.saveStopwatchActivity(stopwatchActivity);
 
         // 스탑워치 정지 메세지 전송 + 목표 진행 시간 업데이트
         Events.raise(

--- a/src/main/java/tosiltosil/backend/module/stopwatch/application/StopwatchService.java
+++ b/src/main/java/tosiltosil/backend/module/stopwatch/application/StopwatchService.java
@@ -37,7 +37,7 @@ public class StopwatchService {
         // 오늘 총 진행 시간 가져오기 - 방금 시작된 스톱워치 시간은 제외
         Duration todayDuration = durationService.getTodayDuration(memberId);
 
-        // 스탑워치 정지 메세지 전송
+        // 스탑워치 시작 메세지 전송
         Events.raise(
                 StopwatchStartedEvent.of(memberId, stopwatch, todayDuration)
         );

--- a/src/main/java/tosiltosil/backend/module/stopwatch/domain/StopwatchActivity.java
+++ b/src/main/java/tosiltosil/backend/module/stopwatch/domain/StopwatchActivity.java
@@ -1,0 +1,52 @@
+package tosiltosil.backend.module.stopwatch.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import tosiltosil.backend.module.stopwatch.domain.value.StopwatchStatus;
+
+import java.util.UUID;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class StopwatchActivity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, columnDefinition = "BINARY(16)")
+    private UUID memberId;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private StopwatchStatus stopwatchStatus;
+
+    @Builder
+    private StopwatchActivity(
+            final UUID memberId,
+            final StopwatchStatus stopwatchStatus
+    ) {
+        this.memberId = memberId;
+        this.stopwatchStatus = stopwatchStatus;
+    }
+
+    public static StopwatchActivity of(final UUID memberId) {
+        return StopwatchActivity.builder()
+                .memberId(memberId)
+                .stopwatchStatus(StopwatchStatus.INACTIVE)
+                .build();
+    }
+    
+    // change status
+    public void changeToActive() {
+        this.stopwatchStatus = StopwatchStatus.ACTIVE;
+    }
+
+    public void changeToInactive() {
+        this.stopwatchStatus = StopwatchStatus.INACTIVE;
+    }
+}

--- a/src/main/java/tosiltosil/backend/module/stopwatch/domain/StopwatchRepository.java
+++ b/src/main/java/tosiltosil/backend/module/stopwatch/domain/StopwatchRepository.java
@@ -1,12 +1,19 @@
 package tosiltosil.backend.module.stopwatch.domain;
 
 import java.util.Optional;
+import java.util.UUID;
 
 public interface StopwatchRepository {
 
+    // stopwatch
     Optional<Stopwatch> findLatestByGoalId(Long goalId);
 
     Stopwatch save(Stopwatch stopwatch);
 
     void delete(Stopwatch stopwatch);
+
+    // stopwatch activity
+    Optional<StopwatchActivity> findStopwatchActivityByMemberId(UUID memberId);
+
+    void saveStopwatchActivity(StopwatchActivity stopwatchActivity);
 }

--- a/src/main/java/tosiltosil/backend/module/stopwatch/domain/event/StopwatchPausedEvent.java
+++ b/src/main/java/tosiltosil/backend/module/stopwatch/domain/event/StopwatchPausedEvent.java
@@ -11,14 +11,14 @@ public record StopwatchPausedEvent(
         String type,
         LocalDateTime startTime,
         LocalDateTime endTime,
-        Duration memberTodayDuration
+        Duration todayDuration
 ) {
 
     public static StopwatchPausedEvent of(
             final UUID memberId,
             final Long goalId,
             final Stopwatch stopwatch,
-            final Duration memberTodayDuration
+            final Duration todayDuration
     ) {
         return new StopwatchPausedEvent(
                 memberId,
@@ -26,7 +26,7 @@ public record StopwatchPausedEvent(
                 "PAUSED",
                 stopwatch.getStartedAt(),
                 stopwatch.getEndedAt(),
-                memberTodayDuration
+                todayDuration
         );
     }
 }

--- a/src/main/java/tosiltosil/backend/module/stopwatch/domain/event/StopwatchPausedEvent.java
+++ b/src/main/java/tosiltosil/backend/module/stopwatch/domain/event/StopwatchPausedEvent.java
@@ -11,14 +11,14 @@ public record StopwatchPausedEvent(
         String type,
         LocalDateTime startTime,
         LocalDateTime endTime,
-        Duration totalTime
+        Duration memberTodayDuration
 ) {
 
     public static StopwatchPausedEvent of(
             final UUID memberId,
             final Long goalId,
             final Stopwatch stopwatch,
-            final Duration totalTime
+            final Duration memberTodayDuration
     ) {
         return new StopwatchPausedEvent(
                 memberId,
@@ -26,7 +26,7 @@ public record StopwatchPausedEvent(
                 "PAUSED",
                 stopwatch.getStartedAt(),
                 stopwatch.getEndedAt(),
-                totalTime
+                memberTodayDuration
         );
     }
 }

--- a/src/main/java/tosiltosil/backend/module/stopwatch/domain/event/StopwatchStartedEvent.java
+++ b/src/main/java/tosiltosil/backend/module/stopwatch/domain/event/StopwatchStartedEvent.java
@@ -9,19 +9,19 @@ public record StopwatchStartedEvent(
         UUID memberId,
         String type,
         LocalDateTime startTime,
-        Duration memberTodayDuration
+        Duration todayDuration
 ) {
 
     public static StopwatchStartedEvent of(
             final UUID memberId,
             final Stopwatch stopwatch,
-            final Duration memberTodayDuration
+            final Duration todayDuration
     ) {
         return new StopwatchStartedEvent(
                 memberId,
                 "STARTED",
                 stopwatch.getStartedAt(),
-                memberTodayDuration
+                todayDuration
         );
     }
 }

--- a/src/main/java/tosiltosil/backend/module/stopwatch/domain/event/StopwatchStartedEvent.java
+++ b/src/main/java/tosiltosil/backend/module/stopwatch/domain/event/StopwatchStartedEvent.java
@@ -9,19 +9,19 @@ public record StopwatchStartedEvent(
         UUID memberId,
         String type,
         LocalDateTime startTime,
-        Duration totalTime
+        Duration memberTodayDuration
 ) {
 
     public static StopwatchStartedEvent of(
             final UUID memberId,
             final Stopwatch stopwatch,
-            final Duration totalTime
+            final Duration memberTodayDuration
     ) {
         return new StopwatchStartedEvent(
                 memberId,
                 "STARTED",
                 stopwatch.getStartedAt(),
-                totalTime
+                memberTodayDuration
         );
     }
 }

--- a/src/main/java/tosiltosil/backend/module/stopwatch/domain/value/StopwatchStatus.java
+++ b/src/main/java/tosiltosil/backend/module/stopwatch/domain/value/StopwatchStatus.java
@@ -1,4 +1,4 @@
-package tosiltosil.backend.module.member.domain.value;
+package tosiltosil.backend.module.stopwatch.domain.value;
 
 public enum StopwatchStatus {
     ACTIVE,

--- a/src/main/java/tosiltosil/backend/module/stopwatch/infrastructure/StopwatchActivityJpaRepository.java
+++ b/src/main/java/tosiltosil/backend/module/stopwatch/infrastructure/StopwatchActivityJpaRepository.java
@@ -1,0 +1,12 @@
+package tosiltosil.backend.module.stopwatch.infrastructure;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import tosiltosil.backend.module.stopwatch.domain.StopwatchActivity;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface StopwatchActivityJpaRepository extends JpaRepository<StopwatchActivity, Long> {
+
+    Optional<StopwatchActivity> findByMemberId(UUID memberId);
+}

--- a/src/main/java/tosiltosil/backend/module/stopwatch/infrastructure/StopwatchRepositoryImpl.java
+++ b/src/main/java/tosiltosil/backend/module/stopwatch/infrastructure/StopwatchRepositoryImpl.java
@@ -1,9 +1,12 @@
 package tosiltosil.backend.module.stopwatch.infrastructure;
 
 import java.util.Optional;
+import java.util.UUID;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import tosiltosil.backend.module.stopwatch.domain.Stopwatch;
+import tosiltosil.backend.module.stopwatch.domain.StopwatchActivity;
 import tosiltosil.backend.module.stopwatch.domain.StopwatchRepository;
 
 @Repository
@@ -11,6 +14,7 @@ import tosiltosil.backend.module.stopwatch.domain.StopwatchRepository;
 public class StopwatchRepositoryImpl implements StopwatchRepository {
 
     private final StopwatchJpaRepository stopwatchJpaRepository;
+    private final StopwatchActivityJpaRepository stopwatchActivityJpaRepository;
 
     @Override
     public Optional<Stopwatch> findLatestByGoalId(final Long goalId) {
@@ -25,5 +29,15 @@ public class StopwatchRepositoryImpl implements StopwatchRepository {
     @Override
     public void delete(final Stopwatch stopwatch) {
         stopwatchJpaRepository.delete(stopwatch);
+    }
+
+    @Override
+    public Optional<StopwatchActivity> findStopwatchActivityByMemberId(final UUID memberId) {
+        return stopwatchActivityJpaRepository.findByMemberId(memberId);
+    }
+
+    @Override
+    public void saveStopwatchActivity(final StopwatchActivity stopwatchActivity) {
+        stopwatchActivityJpaRepository.save(stopwatchActivity);
     }
 }

--- a/src/main/java/tosiltosil/backend/module/stopwatch/presentation/StopwatchWebSocketEventHandler.java
+++ b/src/main/java/tosiltosil/backend/module/stopwatch/presentation/StopwatchWebSocketEventHandler.java
@@ -3,6 +3,7 @@ package tosiltosil.backend.module.stopwatch.presentation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 import tosiltosil.backend.module.stopwatch.domain.event.StopwatchPausedEvent;
 import tosiltosil.backend.module.stopwatch.domain.event.StopwatchStartedEvent;
@@ -15,13 +16,13 @@ public class StopwatchWebSocketEventHandler {
 
     private final SimpMessagingTemplate messagingTemplate;
 
-    @TransactionalEventListener
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleStopwatchStartedEvent(final StopwatchStartedEvent event) {
         StopwatchStartResponse dto = StopwatchStartResponse.fromStartedEvent(event);
         messagingTemplate.convertAndSend("/topic/members/" + dto.memberId() + "/stopwatch", dto);
     }
 
-    @TransactionalEventListener
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleStopwatchPausedEvent(final StopwatchPausedEvent event) {
         StopwatchPauseResponse dto = StopwatchPauseResponse.fromPausedEvent(event);
         messagingTemplate.convertAndSend("/topic/members/" + dto.memberId() + "/stopwatch", dto);

--- a/src/main/java/tosiltosil/backend/module/stopwatch/presentation/dto/StopwatchPauseResponse.java
+++ b/src/main/java/tosiltosil/backend/module/stopwatch/presentation/dto/StopwatchPauseResponse.java
@@ -10,7 +10,7 @@ public record StopwatchPauseResponse(
         String type,
         LocalDateTime startTime,
         LocalDateTime endTime,
-        Duration memberTodayDuration
+        Duration todayDuration
 ) {
 
     public static StopwatchPauseResponse fromPausedEvent(final StopwatchPausedEvent event) {
@@ -19,7 +19,7 @@ public record StopwatchPauseResponse(
                 event.type(),
                 event.startTime(),
                 event.endTime(),
-                event.memberTodayDuration()
+                event.todayDuration()
         );
     }
 }

--- a/src/main/java/tosiltosil/backend/module/stopwatch/presentation/dto/StopwatchPauseResponse.java
+++ b/src/main/java/tosiltosil/backend/module/stopwatch/presentation/dto/StopwatchPauseResponse.java
@@ -10,7 +10,7 @@ public record StopwatchPauseResponse(
         String type,
         LocalDateTime startTime,
         LocalDateTime endTime,
-        Duration totalTime
+        Duration memberTodayDuration
 ) {
 
     public static StopwatchPauseResponse fromPausedEvent(final StopwatchPausedEvent event) {
@@ -19,7 +19,7 @@ public record StopwatchPauseResponse(
                 event.type(),
                 event.startTime(),
                 event.endTime(),
-                event.totalTime()
+                event.memberTodayDuration()
         );
     }
 }

--- a/src/main/java/tosiltosil/backend/module/stopwatch/presentation/dto/StopwatchStartResponse.java
+++ b/src/main/java/tosiltosil/backend/module/stopwatch/presentation/dto/StopwatchStartResponse.java
@@ -9,7 +9,7 @@ public record StopwatchStartResponse(
         UUID memberId,
         String type,
         LocalDateTime startTime,
-        Duration totalTime
+        Duration memberTodayDuration
 ) {
 
     public static StopwatchStartResponse fromStartedEvent(final StopwatchStartedEvent event) {
@@ -17,7 +17,7 @@ public record StopwatchStartResponse(
                 event.memberId(),
                 event.type(),
                 event.startTime(),
-                event.totalTime()
+                event.memberTodayDuration()
         );
     }
 }

--- a/src/main/java/tosiltosil/backend/module/stopwatch/presentation/dto/StopwatchStartResponse.java
+++ b/src/main/java/tosiltosil/backend/module/stopwatch/presentation/dto/StopwatchStartResponse.java
@@ -17,7 +17,7 @@ public record StopwatchStartResponse(
                 event.memberId(),
                 event.type(),
                 event.startTime(),
-                event.memberTodayDuration()
+                event.todayDuration()
         );
     }
 }

--- a/src/test/java/tosiltosil/backend/module/goal/application/GoalEventHandlerTest.java
+++ b/src/test/java/tosiltosil/backend/module/goal/application/GoalEventHandlerTest.java
@@ -1,0 +1,99 @@
+package tosiltosil.backend.module.goal.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import tosiltosil.backend.common.domain.exception.NotFoundException;
+import tosiltosil.backend.module.goal.domain.Goal;
+import tosiltosil.backend.module.goal.domain.GoalRepository;
+import tosiltosil.backend.module.goal.domain.value.GoalStatus;
+import tosiltosil.backend.module.stopwatch.domain.event.StopwatchPausedEvent;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("NonAsciiCharacters")
+class GoalEventHandlerTest {
+
+    @Mock
+    private GoalRepository goalRepository;
+
+    @InjectMocks
+    private GoalEventHandler goalEventHandler;
+
+    @Test
+    void 스톱워치_정지_이벤트로_목표에_진행_시간_추가() {
+        // given
+        UUID memberId = UUID.randomUUID();
+        LocalDateTime startTime = LocalDateTime.of(2024, 1, 1, 10, 0, 0);
+        LocalDateTime endTime = LocalDateTime.of(2024, 1, 1, 11, 30, 0);
+        Duration currentDuration = Duration.ofHours(30);
+        Duration totalTime = Duration.ofHours(3);
+        Duration expectedAddedDuration = Duration.between(startTime, endTime); // 1시간 30분
+
+        Goal goal = createGoal(memberId, totalTime, currentDuration);
+        StopwatchPausedEvent event = new StopwatchPausedEvent(
+                memberId, 1L, "PAUSED", startTime, endTime, currentDuration.plus(expectedAddedDuration)
+        );
+
+        given(goalRepository.findById(any())).willReturn(Optional.of(goal));
+
+        // when
+        goalEventHandler.addDuration(event);
+
+        // then
+        Duration expectedTotalDuration = currentDuration.plus(expectedAddedDuration);
+        assertThat(goal.getDuration()).isEqualTo(expectedTotalDuration);
+    }
+
+    @Test
+    void 추가된_진행_시간으로_목표가_완료되면_상태를_완료로_변경() {
+        // given
+        UUID memberId = UUID.randomUUID();
+        LocalDateTime startTime = LocalDateTime.of(2024, 1, 1, 10, 0, 0);
+        LocalDateTime endTime = LocalDateTime.of(2024, 1, 1, 12, 0, 0);
+        Duration currentDuration = Duration.ofHours(1);
+        Duration totalTime = Duration.ofHours(3);
+        Duration expectedAddedDuration = Duration.between(startTime, endTime);
+
+        // 기존 진행시간 1시간 + 추가 2시간 = 총 3시간으로 목표시간(3시간) 달성
+        Goal goal = createGoal(memberId, totalTime, currentDuration);
+        StopwatchPausedEvent event = new StopwatchPausedEvent(
+                memberId, 1L, "PAUSED", startTime, endTime, currentDuration.plus(expectedAddedDuration)
+        );
+
+        given(goalRepository.findById(any())).willReturn(Optional.of(goal));
+
+        // when
+        goalEventHandler.addDuration(event);
+
+        // then
+        assertThat(goal.getStatus()).isEqualTo(GoalStatus.COMPLETED);
+    }
+
+    private Goal createGoal(UUID memberId, Duration totalTime, Duration currentDuration) {
+        return Goal.builder()
+                .memberId(memberId)
+                .categoryId(1L)
+                .title("Test Goal")
+                .totalTime(totalTime)
+                .status(GoalStatus.RUNNING)
+                .duration(currentDuration)
+                .orderIndex(BigDecimal.valueOf(100000.0))
+                .iconId(1L)
+                .date(LocalDate.now())
+                .build();
+    }
+}

--- a/src/test/java/tosiltosil/backend/module/goal/domain/GoalTest.java
+++ b/src/test/java/tosiltosil/backend/module/goal/domain/GoalTest.java
@@ -151,6 +151,46 @@ class GoalTest {
                 .hasMessage("기간이 지나 실패한 목표입니다.");
     }
 
+    @Test
+    void 목표의_진행_시간이_총_시간보다_크거나_같으면_완료_상태로_변경한다() {
+        // given
+        UUID memberId = UUID.randomUUID();
+        Goal goal = createGoalWithDuration(memberId, Duration.ofHours(2), Duration.ofHours(2));
+        
+        // when
+        goal.changeStatusToCompleted();
+        
+        // then
+        assertThat(goal.getStatus()).isEqualTo(GoalStatus.COMPLETED);
+    }
+
+    @Test
+    void 목표의_진행_시간이_총_시간보다_많아도_완료_상태로_변경한다() {
+        // given
+        UUID memberId = UUID.randomUUID();
+        Goal goal = createGoalWithDuration(memberId, Duration.ofHours(2), Duration.ofHours(3));
+        
+        // when
+        goal.changeStatusToCompleted();
+        
+        // then
+        assertThat(goal.getStatus()).isEqualTo(GoalStatus.COMPLETED);
+    }
+
+    @Test
+    void 목표의_진행_시간이_총_시간보다_적으면_완료_상태로_변경되지_않는다() {
+        // given
+        UUID memberId = UUID.randomUUID();
+        GoalStatus originalStatus = GoalStatus.RUNNING;
+        Goal goal = createGoalWithDuration(memberId, Duration.ofHours(2), Duration.ofMinutes(30));
+        
+        // when
+        goal.changeStatusToCompleted();
+        
+        // then
+        assertThat(goal.getStatus()).isEqualTo(originalStatus);
+    }
+
     private Goal createGoalWithStatus(UUID memberId, GoalStatus status) {
         return Goal.builder()
                 .memberId(memberId)
@@ -159,6 +199,20 @@ class GoalTest {
                 .totalTime(Duration.ofHours(2))
                 .status(status)
                 .duration(Duration.ZERO)
+                .orderIndex(BigDecimal.valueOf(100000.0))
+                .iconId(1L)
+                .date(LocalDate.now())
+                .build();
+    }
+
+    private Goal createGoalWithDuration(UUID memberId, Duration totalTime, Duration duration) {
+        return Goal.builder()
+                .memberId(memberId)
+                .categoryId(1L)
+                .title("Test Goal")
+                .totalTime(totalTime)
+                .status(GoalStatus.RUNNING)
+                .duration(duration)
                 .orderIndex(BigDecimal.valueOf(100000.0))
                 .iconId(1L)
                 .date(LocalDate.now())

--- a/src/test/java/tosiltosil/backend/module/goal/domain/GoalTest.java
+++ b/src/test/java/tosiltosil/backend/module/goal/domain/GoalTest.java
@@ -29,7 +29,7 @@ class GoalTest {
     }
 
     @Test
-    void BEFORE_STARTING_상태에서_시작_상태로_변경한다() {
+    void 목표가_시작_전일_때_시작_상태로_변경한다() {
         // given
         UUID memberId = UUID.randomUUID();
         Goal goal = createGoalWithStatus(memberId, GoalStatus.BEFORE_STARTING);
@@ -42,57 +42,69 @@ class GoalTest {
     }
 
     @Test
-    void PAUSED_상태에서_시작_상태로_변경한다() {
+    void 정지_상태에서_시작_상태로_변경한다() {
         // given
         UUID memberId = UUID.randomUUID();
         Goal goal = createGoalWithStatus(memberId, GoalStatus.PAUSED);
-        
+
         // when
         goal.changeStatusToStarted();
-        
+
         // then
         assertThat(goal.getStatus()).isEqualTo(GoalStatus.RUNNING);
     }
 
     @Test
-    void RUNNING_상태에서_시작_상태로_변경하면_예외가_발생한다() {
+    void 목표가_진행_중일_때_시작_상태로_변경하면_예외가_발생한다() {
         // given
         UUID memberId = UUID.randomUUID();
         Goal goal = createGoalWithStatus(memberId, GoalStatus.RUNNING);
-        
+
         // when & then
         assertThatThrownBy(goal::changeStatusToStarted)
                 .isInstanceOf(ConflictException.class)
-                .hasMessage("스톱워치가 이미 실행되거나 기간이 지난 상태입니다.");
+                .hasMessage("스톱워치가 이미 실행중입니다.");
     }
 
     @Test
-    void COMPLETED_상태에서_시작_상태로_변경하면_예외가_발생한다() {
+    void 완료된_목표를_시작_상태로_변경하면_예외가_발생한다() {
         // given
         UUID memberId = UUID.randomUUID();
         Goal goal = createGoalWithStatus(memberId, GoalStatus.COMPLETED);
-        
+
         // when & then
         assertThatThrownBy(goal::changeStatusToStarted)
                 .isInstanceOf(ConflictException.class)
-                .hasMessage("스톱워치가 이미 실행되거나 기간이 지난 상태입니다.");
+                .hasMessage("이미 완료된 목표입니다.");
     }
 
     @Test
-    void RUNNING_상태에서_일시정지_상태로_변경한다() {
+    void 실패한_목표를_시작_상태로_변경하면_예외가_발생한다() {
+        // given
+        UUID memberId = UUID.randomUUID();
+        Goal goal = createGoalWithStatus(memberId, GoalStatus.FAILED);
+
+        // when & then
+        assertThatThrownBy(goal::changeStatusToStarted)
+                .isInstanceOf(ConflictException.class)
+                .hasMessage("기간이 지나 실패한 목표입니다.");
+    }
+
+    @Test
+    void 목표가_진행_중일_때_정지_상태로_변경한다() {
         // given
         UUID memberId = UUID.randomUUID();
         Goal goal = createGoalWithStatus(memberId, GoalStatus.RUNNING);
-        
+
         // when
         goal.changeStatusToPaused();
-        
+
         // then
         assertThat(goal.getStatus()).isEqualTo(GoalStatus.PAUSED);
     }
 
     @Test
-    void BEFORE_STARTING_상태에서_일시정지_상태로_변경하면_예외가_발생한다() {
+    void 목표가_시작_전일_때_정지_상태로_변경하면_예외가_발생한다() {
         // given
         UUID memberId = UUID.randomUUID();
         Goal goal = createGoalWithStatus(memberId, GoalStatus.BEFORE_STARTING);
@@ -104,7 +116,7 @@ class GoalTest {
     }
 
     @Test
-    void PAUSED_상태에서_일시정지_상태로_변경하면_예외가_발생한다() {
+    void 정지_상태에서_정지_상태로_변경하면_예외가_발생한다() {
         // given
         UUID memberId = UUID.randomUUID();
         Goal goal = createGoalWithStatus(memberId, GoalStatus.PAUSED);
@@ -113,6 +125,30 @@ class GoalTest {
         assertThatThrownBy(goal::changeStatusToPaused)
                 .isInstanceOf(ConflictException.class)
                 .hasMessage("스톱워치가 이미 정지되었습니다.");
+    }
+
+    @Test
+    void 완료된_목표를_정지_상태로_변경하면_예외가_발생한다() {
+        // given
+        UUID memberId = UUID.randomUUID();
+        Goal goal = createGoalWithStatus(memberId, GoalStatus.COMPLETED);
+        
+        // when & then
+        assertThatThrownBy(goal::changeStatusToPaused)
+                .isInstanceOf(ConflictException.class)
+                .hasMessage("이미 완료된 목표입니다.");
+    }
+
+    @Test
+    void 실패한_목표를_정지_상태로_변경하면_예외가_발생한다() {
+        // given
+        UUID memberId = UUID.randomUUID();
+        Goal goal = createGoalWithStatus(memberId, GoalStatus.FAILED);
+        
+        // when & then
+        assertThatThrownBy(goal::changeStatusToPaused)
+                .isInstanceOf(ConflictException.class)
+                .hasMessage("기간이 지나 실패한 목표입니다.");
     }
 
     private Goal createGoalWithStatus(UUID memberId, GoalStatus status) {


### PR DESCRIPTION
## 🔢 Issue Number
<!-- close #{issue-number} when solved issue -->
<!-- relates to #{issue-number} when just link without closing -->
close #58 
close #61 
close #65 

## 👨‍💻 작업 내용
<!-- 회원 비밀번호 저장 암호화 알고리즘을 수정했습니다. --> 
### 스탑워치 정지 API에 완료 확인 기능 추가
스탑워치 완료 API를 따로 만들지 않고 정지 API에 완료되었는지 검증하고 확인하는 기능을 추가했습니다.

스탑워치가 정지될 경우 이벤트(`StopwatchPausedEvent`)를 통해 목표 service로직에서 성취한 시간을 비교하여 완료 상태를 업데이트합니다.

### 스탑워치 활성화 로직 추가
스탑워치를 시작하거나 정지할 때 사용자의 스탑워치 활성화 여부 상태를 업데이트합니다.
- 시작할 때: 활성화
- 정지할 때: 비활성화

### 스탑워치 활성화 entity 추출
기존 `member` 패키지에 있었던 스탑워치 활성화 상태를 따로 Entity로 추출 후 `stopwatch` 패키지에 포함시켰습니다. 자세한 이유는 #61 이슈를 참고해주세요!

### Transactional event listener phase 
`StopwatchWebsocketEventHandler`에서 기존에 `BEFORE_COMMIT`으로 설정했을 때, 구독자들에게 send 보내는 도중 커넥션 에러 등으로 인해 롤백하는 상황이 발생하면, 일부 사람들은 스탑워치가 시작되었다고 전달받고 나머지 사람들은 전달받지 못하는 상황이 생깁니다. 또한 전달받은 사람들은 롤백되었는지도 모른 채 잘못된 데이터의 스탑워치를 보고있게 됩니다. 즉, "유령 읽기" 상황이 발생합니다.

그래서 이를 해결하고자, 트랜잭션을 완료한 이후에 로직이 동작할 수 있도록 `AFTER_COMMIT`으로 수정했습니다.

## 🤔 고민할 점
<!-- ERD 설계에서 어떻게 해야할 지 모르겠습니다. -->
- Websocket 구독 요청을 테스트해보고 싶습니다..

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 스톱워치 활동 상태를 관리하는 기능이 추가되어, 사용자의 스톱워치 시작/일시정지 시 활동 상태가 기록 및 갱신됩니다.
  * 목표(Goal) 상태 관리가 개선되어, 진행 시간에 따라 자동으로 완료 상태로 변경됩니다.

* **Bug Fixes**
  * 목표 상태 전환 시 예외 처리 및 상태 검증 로직이 명확하게 개선되었습니다.

* **Documentation**
  * 스톱워치 정지 관련 API 사용법에 대한 설명이 문서에 추가되었습니다.

* **Refactor**
  * 일일 누적 시간 필드명이 더 명확하게 변경되어, 응답 및 이벤트에서 일관되게 사용됩니다.
  * 목표 상태 변경 로직이 모듈화되고 명확하게 리팩토링되었습니다.
  * 스톱워치 이벤트 처리 시 트랜잭션 커밋 후 실행되도록 변경되었습니다.

* **Tests**
  * 목표 상태 전환 및 스톱워치 활동 관련 테스트가 추가 및 확장되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->