### PR TITLE
[#60] 목표 삭제 시 성취 시간 차감 기능 추가

### DIFF
--- a/src/main/java/tosiltosil/backend/module/category/application/CategoryService.java
+++ b/src/main/java/tosiltosil/backend/module/category/application/CategoryService.java
@@ -117,16 +117,20 @@ public class CategoryService {
             final UUID memberId,
             final Long categoryId
     ) {
+        // 카테고리 본인 로직인지 확인
         Category category = categoryRepository.findById(categoryId).orElseThrow(() -> new NotFoundException("카테고리가 존재하지 않습니다."));
         category.validateIsMine(memberId);
 
-        Duration deletedTotalDuration = goalService.deleteGoalsAndCalculateTotalDuration(memberId, categoryId);
+        // 카테고리 내 목표의 총 성취 시간 계산
+        Duration deletedTotalDuration = goalService.getGoalTotalDuration(memberId, categoryId);
 
+        // 카테고리에 속한 목표 전부 삭제(커밋 이전) + 사용자 목표 성취 시간 차감(커밋 이후)
+        Events.raise(
+                CategoryDeletedEvent.of(memberId, categoryId, deletedTotalDuration)
+        );
+
+        // 카테고리 삭제
         categoryRepository.delete(category);
-
-        if (deletedTotalDuration.compareTo(Duration.ZERO) > 0) {
-            Events.raise(CategoryDeletedEvent.of(memberId, deletedTotalDuration));
-        }
 
         return CategoryResponse.of(category.getId());
     }

--- a/src/main/java/tosiltosil/backend/module/category/domain/event/CategoryDeletedEvent.java
+++ b/src/main/java/tosiltosil/backend/module/category/domain/event/CategoryDeletedEvent.java
@@ -5,10 +5,11 @@ import java.util.UUID;
 
 public record CategoryDeletedEvent(
         UUID memberId,
+        Long categoryId,
         Duration deletedTotalDuration
 ) {
     
-    public static CategoryDeletedEvent of(final UUID memberId, final Duration deletedTotalDuration) {
-        return new CategoryDeletedEvent(memberId, deletedTotalDuration);
+    public static CategoryDeletedEvent of(final UUID memberId, final Long categoryId, final Duration deletedTotalDuration) {
+        return new CategoryDeletedEvent(memberId, categoryId, deletedTotalDuration);
     }
 }

--- a/src/main/java/tosiltosil/backend/module/duration/application/DurationEventHandler.java
+++ b/src/main/java/tosiltosil/backend/module/duration/application/DurationEventHandler.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 import tosiltosil.backend.module.category.domain.event.CategoryDeletedEvent;
+import tosiltosil.backend.module.goal.domain.event.GoalDeletedEvent;
 
 @Component
 @RequiredArgsConstructor
@@ -16,5 +17,10 @@ public class DurationEventHandler {
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleCategoryDeletedEvent(final CategoryDeletedEvent event) {
         durationService.subtractTodayDuration(event.memberId(), event.deletedTotalDuration());
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleGoalDeletedEvent(final GoalDeletedEvent event) {
+        durationService.subtractTodayDuration(event.memberId(), event.deletedDuration());
     }
 }

--- a/src/main/java/tosiltosil/backend/module/goal/application/GoalEventHandler.java
+++ b/src/main/java/tosiltosil/backend/module/goal/application/GoalEventHandler.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 import tosiltosil.backend.common.domain.exception.NotFoundException;
+import tosiltosil.backend.module.category.domain.event.CategoryDeletedEvent;
 import tosiltosil.backend.module.goal.domain.Goal;
 import tosiltosil.backend.module.goal.domain.GoalRepository;
 import tosiltosil.backend.module.stopwatch.domain.event.StopwatchPausedEvent;
@@ -23,5 +24,11 @@ public class GoalEventHandler {
 
         Duration addedDuration = Duration.between(event.startTime(), event.endTime());
         goal.addDuration(addedDuration);
+    }
+    
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    public void handleCategoryDeletedEvent(final CategoryDeletedEvent event) {
+        // 카테고리에 속한 목표 모두 삭제
+        goalRepository.deleteAllByMemberIdAndCategoryId(event.memberId(), event.categoryId());
     }
 }

--- a/src/main/java/tosiltosil/backend/module/goal/application/GoalService.java
+++ b/src/main/java/tosiltosil/backend/module/goal/application/GoalService.java
@@ -49,6 +49,18 @@ public class GoalService {
     }
 
     @Transactional
+    public Duration getGoalTotalDuration(
+            final UUID memberId,
+            final Long categoryId
+    ) {
+        List<Goal> goalsToDelete = goalRepository.findTotalGoals(memberId, categoryId);
+
+        return goalsToDelete.stream()
+                .map(Goal::getDuration)
+                .reduce(Duration.ZERO, Duration::plus);
+    }
+
+    @Transactional
     public GoalIdsResponse createGoal(
             final UUID memberId,
             final GoalCreateRequest request
@@ -151,19 +163,6 @@ public class GoalService {
         );
 
         return GoalIdResponse.of(goal.getId());
-    }
-
-    @Transactional
-    public Duration deleteGoalsAndCalculateTotalDuration(final UUID memberId, final Long categoryId) {
-        List<Goal> goalsToDelete = goalRepository.findTotalGoals(memberId, categoryId);
-
-        Duration totalDuration = goalsToDelete.stream()
-                .map(Goal::getDuration)
-                .reduce(Duration.ZERO, Duration::plus);
-
-        goalsToDelete.forEach(goalRepository::delete);
-
-        return totalDuration;
     }
 
     @Transactional

--- a/src/main/java/tosiltosil/backend/module/goal/application/GoalService.java
+++ b/src/main/java/tosiltosil/backend/module/goal/application/GoalService.java
@@ -48,7 +48,7 @@ public class GoalService {
         return DayGoalsResponse.of(overallPercentage, categoryResponses);
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public Duration getGoalTotalDuration(
             final UUID memberId,
             final Long categoryId

--- a/src/main/java/tosiltosil/backend/module/goal/application/GoalService.java
+++ b/src/main/java/tosiltosil/backend/module/goal/application/GoalService.java
@@ -53,9 +53,9 @@ public class GoalService {
             final UUID memberId,
             final Long categoryId
     ) {
-        List<Goal> goalsToDelete = goalRepository.findTotalGoals(memberId, categoryId);
+        List<Goal> goals = goalRepository.findTotalGoals(memberId, categoryId);
 
-        return goalsToDelete.stream()
+        return goals.stream()
                 .map(Goal::getDuration)
                 .reduce(Duration.ZERO, Duration::plus);
     }

--- a/src/main/java/tosiltosil/backend/module/goal/application/GoalService.java
+++ b/src/main/java/tosiltosil/backend/module/goal/application/GoalService.java
@@ -11,8 +11,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import tosiltosil.backend.common.domain.exception.NotFoundException;
 import tosiltosil.backend.common.domain.order.OrderManager;
+import tosiltosil.backend.common.messaging.Events;
 import tosiltosil.backend.module.goal.domain.Goal;
 import tosiltosil.backend.module.goal.domain.GoalRepository;
+import tosiltosil.backend.module.goal.domain.event.GoalDeletedEvent;
 import tosiltosil.backend.module.goal.domain.request.GoalCreateRequest;
 import tosiltosil.backend.module.goal.domain.request.GoalOrderChangeRequest;
 import tosiltosil.backend.module.goal.domain.request.GoalUpdateRequest;
@@ -140,7 +142,14 @@ public class GoalService {
         Goal goal = goalRepository.findById(goalId).orElseThrow(() -> new NotFoundException("목표가 존재하지 않습니다."));
         goal.validateIsMine(memberId);
 
+        // 목표 삭제
         goalRepository.delete(goal);
+
+        // 사용자 목표 성취 시간 차감
+        Events.raise(
+                GoalDeletedEvent.of(memberId, goal.getDuration())
+        );
+
         return GoalIdResponse.of(goal.getId());
     }
 

--- a/src/main/java/tosiltosil/backend/module/goal/domain/GoalRepository.java
+++ b/src/main/java/tosiltosil/backend/module/goal/domain/GoalRepository.java
@@ -26,4 +26,6 @@ public interface GoalRepository {
     List<Goal> saveAll(List<Goal> goals);
 
     void delete(Goal goal);
+
+    void deleteAllByMemberIdAndCategoryId(UUID memberId, Long categoryId);
 }

--- a/src/main/java/tosiltosil/backend/module/goal/domain/event/GoalDeletedEvent.java
+++ b/src/main/java/tosiltosil/backend/module/goal/domain/event/GoalDeletedEvent.java
@@ -1,0 +1,14 @@
+package tosiltosil.backend.module.goal.domain.event;
+
+import java.time.Duration;
+import java.util.UUID;
+
+public record GoalDeletedEvent(
+        UUID memberId,
+        Duration deletedDuration
+) {
+
+    public static GoalDeletedEvent of(final UUID memberId, final Duration deletedDuration) {
+        return new GoalDeletedEvent(memberId, deletedDuration);
+    }
+}

--- a/src/main/java/tosiltosil/backend/module/goal/infrastructure/GoalJpaRepository.java
+++ b/src/main/java/tosiltosil/backend/module/goal/infrastructure/GoalJpaRepository.java
@@ -20,4 +20,6 @@ public interface GoalJpaRepository extends JpaRepository<Goal, Long> {
 
     @Query("SELECT MAX(g.orderIndex) FROM Goal g WHERE g.memberId = :memberId AND g.date = :date")
     Optional<BigDecimal> findMaxOrderIndexByMemberIdAndDate(@Param("memberId") UUID memberId, @Param("date") LocalDate date);
+
+    void deleteAllByMemberIdAndCategoryId(UUID memberId, Long categoryId);
 }

--- a/src/main/java/tosiltosil/backend/module/goal/infrastructure/GoalRepositoryImpl.java
+++ b/src/main/java/tosiltosil/backend/module/goal/infrastructure/GoalRepositoryImpl.java
@@ -65,4 +65,9 @@ public class GoalRepositoryImpl implements GoalRepository {
     public void delete(final Goal goal) {
         goalJpaRepository.delete(goal);
     }
+
+    @Override
+    public void deleteAllByMemberIdAndCategoryId(UUID memberId, Long categoryId) {
+        goalJpaRepository.deleteAllByMemberIdAndCategoryId(memberId, categoryId);
+    }
 }


### PR DESCRIPTION
## 🔢 Issue Number
<!-- close #{issue-number} when solved issue -->
<!-- relates to #{issue-number} when just link without closing -->
close #60 

## 👨‍💻 작업 내용
<!-- 회원 비밀번호 저장 암호화 알고리즘을 수정했습니다. --> 
### 1.
목표 삭제 시 해당 목표만큼 성취한 시간을 `duration`에서 차감하는 로직을 추가했습니다.

### 2.
카테고리 삭제 시 목표 삭제 후 계산하는 메서드의 책임을 2개로 분리했습니다.

## 🤔 고민할 점
<!-- ERD 설계에서 어떻게 해야할 지 모르겠습니다. -->

## 🔮 추후에 추가할 점
- service 코드 책임을 확실하게 분리하고 BDD 스타일의 테스트 코드를 접목시켜서 코드 가독성을 높일 예정입니다!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 카테고리 삭제 시 목표들의 총 지속 시간을 계산하고, 삭제 이벤트를 통해 목표 삭제 및 사용자 기록이 연동 처리됩니다.
  * 목표 삭제 시 목표의 지속 시간이 이벤트로 처리되어 사용자 기록에 반영됩니다.
  * 목표 삭제 및 카테고리 삭제 관련 이벤트 핸들러가 추가되어 데이터 처리 자동화가 강화되었습니다.

* **버그 수정**
  * 카테고리 및 목표 삭제 시 연관된 목표 및 기록 데이터가 누락 없이 정확하게 처리됩니다.

* **기타**
  * 내부 이벤트 및 데이터 처리 구조가 개선되어 삭제 작업의 안정성과 일관성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->