### PR TITLE
[#80] 회원가입 시, 임시 토큰 만료 검증 순서 수정

### DIFF
--- a/src/main/java/tosiltosil/backend/module/auth/application/AuthService.java
+++ b/src/main/java/tosiltosil/backend/module/auth/application/AuthService.java
@@ -41,10 +41,10 @@ public class AuthService {
             final CreateLocalMemberRequest request,
             final MultipartFile profileImage
     ) {
-        termsService.validateTerms(request.terms());
-
         String email = getEmailFromRedis(temporaryToken);
         memberService.validateEmailIsExist(email, LOCAL.name());
+
+        termsService.validateTerms(request.terms());
 
         String code = memberService.generateRandomCode();
         String profileImgUrl = "https://example.com/profile.png"; // S3 구현 후 수정


### PR DESCRIPTION
## 🔢 Issue Number
close #80 

## 👨‍💻 작업 내용
회원가입 시, 임시 토큰이 만료되었음에도 약관에 대한 검증을 진행하는 문제를 해결하기 위해
임시 토큰의 만료 여부를 먼저 확인하도록 로직 순서를 수정했습니다!

## 🤔 고민할 점
<!-- ERD 설계에서 어떻게 해야할 지 모르겠습니다. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * 회원가입 시 약관 동의 검증 시점이 이메일 중복 확인 이후로 변경되었습니다.  
  (기능상 변화는 없으며, 사용자 경험에는 영향이 없습니다.)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->