### PR TITLE
[#79] RestDocsTestSupport에 Cookie Descriptor 메서드 추가

### DIFF
--- a/src/test/java/tosiltosil/backend/module/auth/presentation/LoginControllerRestDocsTest.java
+++ b/src/test/java/tosiltosil/backend/module/auth/presentation/LoginControllerRestDocsTest.java
@@ -29,7 +29,6 @@ import java.util.UUID;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.springframework.restdocs.cookies.CookieDocumentation.cookieWithName;
 import static org.springframework.restdocs.cookies.CookieDocumentation.responseCookies;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
@@ -86,8 +85,8 @@ public class LoginControllerRestDocsTest extends RestDocsTestSupport {
                 .hasStatus(HttpStatus.OK)
                 .apply(documentHandler.document(
                         responseCookies(
-                                cookieWithName("access-token").description("엑세스 토큰 쿠키"),
-                                cookieWithName("refresh-token").description("리프레시 토큰 쿠키")
+                                responseCookie("access-token", "엑세스 토큰 쿠키"),
+                                responseCookie("refresh-token", "리프레시 토큰 쿠키")
                         ),
                         requestFields(
                                 requestField("email", JsonFieldType.STRING, "이메일 주소", false, "이메일 형식만 가능", "test@example.com"),

--- a/src/test/java/tosiltosil/backend/module/auth/presentation/ReissueControllerRestDocsTest.java
+++ b/src/test/java/tosiltosil/backend/module/auth/presentation/ReissueControllerRestDocsTest.java
@@ -65,11 +65,11 @@ public class ReissueControllerRestDocsTest extends RestDocsTestSupport {
                 .hasStatus(HttpStatus.OK)
                 .apply(documentHandler.document(
                         requestCookies(
-                                cookieWithName("refresh-token").description("이전 리프레시 토큰 쿠키")
+                                requestCookie("refresh-token", "이전 리프레시 토큰 쿠키")
                         ),
                         responseCookies(
-                                cookieWithName("access-token").description("엑세스 토큰 쿠키"),
-                                cookieWithName("refresh-token").description("리프레시 토큰 쿠키")
+                                responseCookie("access-token", "엑세스 토큰 쿠키"),
+                                responseCookie("refresh-token", "리프레시 토큰 쿠키")
                         ),
                         responseFields(
                                 responseField("status", JsonFieldType.NUMBER, "응답 상태 코드", "200"),

--- a/src/test/java/tosiltosil/backend/module/auth/presentation/SignUpControllerRestDocsTest.java
+++ b/src/test/java/tosiltosil/backend/module/auth/presentation/SignUpControllerRestDocsTest.java
@@ -22,7 +22,6 @@ import java.nio.charset.StandardCharsets;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
-import static org.springframework.restdocs.cookies.CookieDocumentation.cookieWithName;
 import static org.springframework.restdocs.cookies.CookieDocumentation.requestCookies;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.multipart;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestPartFields;
@@ -98,7 +97,7 @@ public class SignUpControllerRestDocsTest extends RestDocsTestSupport {
                                         requestField("terms[].agreed", JsonFieldType.BOOLEAN, "약관 동의 여부", false, "boolean 값만 허용됨", "true")
                                 ),
                                 requestCookies(
-                                        cookieWithName("temporary-token").description("임의 엑세스 토큰 쿠키")
+                                        requestCookie("temporary-token", "임의 엑세스 토큰 쿠키")
                                 ),
                                 responseFields(
                                         responseField("status", JsonFieldType.NUMBER, "응답 상태 코드", "201"),

--- a/src/test/java/tosiltosil/backend/module/email/presentation/EmailControllerRestDocsTest.java
+++ b/src/test/java/tosiltosil/backend/module/email/presentation/EmailControllerRestDocsTest.java
@@ -23,7 +23,6 @@ import tosiltosil.backend.support.RestDocsTestSupport;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.springframework.restdocs.cookies.CookieDocumentation.cookieWithName;
 import static org.springframework.restdocs.cookies.CookieDocumentation.responseCookies;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
@@ -294,7 +293,7 @@ class EmailControllerRestDocsTest extends RestDocsTestSupport {
                 .hasStatus(HttpStatus.OK)
                 .apply(documentHandler.document(
                         responseCookies(
-                                cookieWithName("temporary-token").description("임시 엑세스 토큰 쿠키")
+                                responseCookie("temporary-token", "임의 엑세스 토큰 쿠키")
                         ),
                         requestFields(
                                 requestField("email", JsonFieldType.STRING, "이메일 주소", false, "이메일 형식만 가능", "test@example.com"),

--- a/src/test/java/tosiltosil/backend/support/RestDocsTestSupport.java
+++ b/src/test/java/tosiltosil/backend/support/RestDocsTestSupport.java
@@ -6,6 +6,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.restdocs.cookies.CookieDescriptor;
 import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
 import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
 import org.springframework.restdocs.operation.preprocess.Preprocessors;
@@ -24,6 +25,7 @@ import tosiltosil.backend.module.goal.presentation.GoalController;
 import tosiltosil.backend.module.stopwatch.presentation.StopwatchController;
 import tosiltosil.backend.support.RestDocsTestSupport.RestDocsTestConfig;
 
+import static org.springframework.restdocs.cookies.CookieDocumentation.cookieWithName;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.partWithName;
@@ -44,6 +46,18 @@ public abstract class RestDocsTestSupport {
 
     @Autowired
     protected RestDocumentationResultHandler documentHandler;
+
+    protected static CookieDescriptor requestCookie(
+            final String name,
+            final String description) {
+        return cookieWithName(name).description(description);
+    }
+
+    protected static CookieDescriptor responseCookie(
+            final String name,
+            final String description) {
+        return cookieWithName(name).description(description);
+    }
 
     protected static RequestPartDescriptor requestPart(
             final String name,


### PR DESCRIPTION
## 🔢 Issue Number
close #79 

## 👨‍💻 작업 내용
RestDocsTestSupport에 `RequestCookie()` 와 `ResponseCookie()` 메서드를 추가하였습니다.

기존에는 테스트 코드에 직접 `cookieWithName(name).description(description)` 형식의 코드를 작성하였지만,
RestDocsTestSupport 클래스에서 문서화 메서드를 관리하고 있다는 것을 고려하여 통일성을 위해 수정했습니다!

## 🤔 고민할 점
<!-- ERD 설계에서 어떻게 해야할 지 모르겠습니다. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **테스트**
  * REST Docs 테스트에서 쿠키 문서화 방식을 개선하여, 요청 및 응답 쿠키를 보다 명확하게 문서화할 수 있도록 변경되었습니다.
  * 테스트 지원 클래스에 요청 및 응답 쿠키 문서화를 위한 헬퍼 메서드가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->