### PR TITLE
[#87] 인증 쿠키 누락 시 401 에러 및 CustomException 반환 로직 추가

### DIFF
--- a/src/main/java/tosiltosil/backend/common/auth/config/SecurityConfig.java
+++ b/src/main/java/tosiltosil/backend/common/auth/config/SecurityConfig.java
@@ -18,12 +18,16 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import tosiltosil.backend.common.auth.JwtTokenProvider;
 import tosiltosil.backend.common.auth.filter.JwtAuthFilter;
 import tosiltosil.backend.common.util.CookieUtil;
+import tosiltosil.backend.common.web.handler.CustomAccessDeniedHandler;
+import tosiltosil.backend.common.web.handler.CustomAuthenticationEntryPoint;
 
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
 
+    private final CustomAccessDeniedHandler accessDeniedHandler;
+    private final CustomAuthenticationEntryPoint authenticationEntryPoint;
     private final JwtTokenProvider jwtTokenProvider;
     private final CookieUtil cookieUtil;
 
@@ -33,6 +37,10 @@ public class SecurityConfig {
                 .csrf(CsrfConfigurer<HttpSecurity>::disable)
                 .formLogin(FormLoginConfigurer<HttpSecurity>::disable)
                 .httpBasic(HttpBasicConfigurer<HttpSecurity>::disable)
+                .exceptionHandling(e -> e
+                        .authenticationEntryPoint(authenticationEntryPoint)
+                        .accessDeniedHandler(accessDeniedHandler)
+                )
                 .headers(it -> it.frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin))
                 .sessionManagement(it -> it.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(authorize -> authorize

--- a/src/main/java/tosiltosil/backend/common/web/handler/CustomAccessDeniedHandler.java
+++ b/src/main/java/tosiltosil/backend/common/web/handler/CustomAccessDeniedHandler.java
@@ -1,0 +1,55 @@
+package tosiltosil.backend.common.web.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+import tosiltosil.backend.common.logging.domain.InfoLog;
+import tosiltosil.backend.common.web.response.ErrorResponse;
+
+import java.io.IOException;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        int statusCode;
+        String errorMessage;
+
+        if (authentication instanceof AnonymousAuthenticationToken) {
+            statusCode = HttpServletResponse.SC_UNAUTHORIZED;
+            errorMessage = "인증에 실패했습니다.";
+        } else {
+            statusCode = HttpServletResponse.SC_FORBIDDEN;
+            errorMessage = "요청에 대한 권한이 없습니다.";
+        }
+
+        ErrorResponse errorResponse = ErrorResponse.of(
+                statusCode,
+                errorMessage,
+                List.of()
+        );
+
+        response.setStatus(statusCode);
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        InfoLog.of(errorMessage).writeLog();
+
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+}

--- a/src/main/java/tosiltosil/backend/common/web/handler/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/tosiltosil/backend/common/web/handler/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,42 @@
+package tosiltosil.backend.common.web.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+import tosiltosil.backend.common.logging.domain.InfoLog;
+import tosiltosil.backend.common.web.response.ErrorResponse;
+
+import java.io.IOException;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        int statusCode = HttpServletResponse.SC_UNAUTHORIZED;
+        String errorMessage = "인증에 실패했습니다.";
+
+        ErrorResponse errorResponse = ErrorResponse.of(
+                statusCode,
+                errorMessage,
+                List.of()
+        );
+
+        response.setStatus(statusCode);
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        InfoLog.of(errorMessage).writeLog();
+
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+}

--- a/src/test/java/tosiltosil/backend/common/web/handler/CustomAccessDeniedHandlerTest.java
+++ b/src/test/java/tosiltosil/backend/common/web/handler/CustomAccessDeniedHandlerTest.java
@@ -1,0 +1,132 @@
+package tosiltosil.backend.common.web.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import tosiltosil.backend.common.web.response.ErrorResponse;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CustomAccessDeniedHandlerTest {
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @Mock
+    private SecurityContext securityContext;
+
+    @Mock
+    private AccessDeniedException accessDeniedException;
+
+    private CustomAccessDeniedHandler customAccessDeniedHandler;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeEach
+    void setUp() {
+        customAccessDeniedHandler = new CustomAccessDeniedHandler(objectMapper);
+        SecurityContextHolder.setContext(securityContext);
+    }
+
+    @AfterEach
+    void tearDown() {
+        // 테스트 후 SecurityContextHolder를 초기화하여 테스트 간 격리 보장
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void 인증되지_않은_사용자가_접근_시_401_반환() throws IOException, ServletException {
+        // given
+        // 익명 사용자(AnonymousAuthenticationToken) 설정
+        Authentication anonymousAuth = new AnonymousAuthenticationToken("key", "anonymousUser",
+                AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS"));
+
+        when(securityContext.getAuthentication()).thenReturn(anonymousAuth);
+
+        StringWriter stringWriter = prepareResponseWriter();
+
+        ErrorResponse errorResponse = ErrorResponse.of(
+                HttpServletResponse.SC_UNAUTHORIZED,
+                "인증에 실패했습니다.",
+                Collections.emptyList()
+        );
+
+        String expectedJson = objectMapper.writeValueAsString(errorResponse);
+
+        // when
+        customAccessDeniedHandler.handle(request, response, accessDeniedException);
+
+        // then
+        verify(response).setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        verify(response).setContentType("application/json");
+        verify(response).setCharacterEncoding("UTF-8");
+
+        assertEquals(expectedJson, stringWriter.toString());
+    }
+
+    @Test
+    void 권한이_없는_사용자가_접근_시_403_반환() throws IOException, ServletException {
+        // given
+        // 인증된 사용자(UsernamePasswordAuthenticationToken) 설정
+        Authentication authenticatedAuth = new UsernamePasswordAuthenticationToken("user", "password",
+                AuthorityUtils.createAuthorityList("ROLE_USER"));
+        when(securityContext.getAuthentication()).thenReturn(authenticatedAuth);
+
+        StringWriter stringWriter = prepareResponseWriter();
+
+        ErrorResponse errorResponse = ErrorResponse.of(
+                HttpServletResponse.SC_FORBIDDEN,
+                "요청에 대한 권한이 없습니다.",
+                List.of()
+        );
+
+        String expectedJson = objectMapper.writeValueAsString(errorResponse);
+
+        // when
+        customAccessDeniedHandler.handle(request, response, accessDeniedException);
+
+        // then
+        verify(response).setStatus(HttpServletResponse.SC_FORBIDDEN);
+        verify(response).setContentType("application/json");
+        verify(response).setCharacterEncoding("UTF-8");
+
+        assertEquals(expectedJson, stringWriter.toString());
+    }
+
+    /**
+     * HttpServletResponse의 getWriter()가 StringWriter를 반환하도록 설정하여 응답 본문 캡처
+     *
+     * @return StringWriter
+     */
+    private StringWriter prepareResponseWriter() throws IOException {
+        StringWriter stringWriter = new StringWriter();
+        PrintWriter writer = new PrintWriter(stringWriter);
+        when(response.getWriter()).thenReturn(writer);
+        return stringWriter;
+    }
+}

--- a/src/test/java/tosiltosil/backend/common/web/handler/CustomAuthenticationEntryPointTest.java
+++ b/src/test/java/tosiltosil/backend/common/web/handler/CustomAuthenticationEntryPointTest.java
@@ -1,0 +1,79 @@
+package tosiltosil.backend.common.web.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.AuthenticationException;
+import tosiltosil.backend.common.web.response.ErrorResponse;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CustomAuthenticationEntryPointTest {
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @Mock
+    private AuthenticationException authException;
+
+    private CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeEach
+    void setUp() {
+        customAuthenticationEntryPoint = new CustomAuthenticationEntryPoint(objectMapper);
+    }
+
+    @Test
+    void 인증_실패_시_401_반환() throws IOException, ServletException, IOException {
+        // given
+        StringWriter stringWriter = prepareResponseWriter();
+
+        ErrorResponse errorResponse = ErrorResponse.of(
+                HttpServletResponse.SC_UNAUTHORIZED,
+                "인증에 실패했습니다.",
+                List.of()
+        );
+
+        String expectedJson = objectMapper.writeValueAsString(errorResponse);
+
+        // when
+        customAuthenticationEntryPoint.commence(request, response, authException);
+
+        // then
+        verify(response).setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        verify(response).setContentType("application/json");
+        verify(response).setCharacterEncoding("UTF-8");
+
+        assertEquals(expectedJson, stringWriter.toString());
+    }
+
+    /**
+     * HttpServletResponse의 getWriter()가 StringWriter를 반환하도록 설정하여 응답 본문 캡처
+     *
+     * @return StringWriter
+     */
+    private StringWriter prepareResponseWriter() throws IOException {
+        StringWriter stringWriter = new StringWriter();
+        PrintWriter writer = new PrintWriter(stringWriter);
+        when(response.getWriter()).thenReturn(writer);
+        return stringWriter;
+    }
+}


### PR DESCRIPTION
## 🔢 Issue Number
close #86 
close #87 

## 👨‍💻 작업 내용
### 쿠키 누락 시, 401 Unauthorized를 반환하도록 수정

인가되지 않은 요청에 대한 처리를 담당하는 AccessDeniedHandler의 커스텀 클래스를 생성하였습니다.

`AccessDeniedHandler`의 `handle()` 메서드를 오버라이드하여 SecurityContextHolder.getContext().getAuthentication() 가 AnonymousAuthenticationToken 타입인지 확인하고, 아래와 같이 처리했습니다.
1. 익명의 사용자라고 판단된다면 쿠키가 누락됐다는 뜻이므로 401 예외 반환
2. 인증이 됐는데 권한이 없는 사용자라면 403 예외를 반환하도록 수정했습니다.

### CustomException으로 예외처리 하도록 수정

인증이 되지 않은 요청에 대한 처리를 담당하는 AuthenticationEntryPoint의 커스텀 클래스를 생성하였습니다.

그리고 CustomAccessDeniedHandler와 CustomAuthenticationEntryPoint에서 예외가 발생할 때, CustomException 형태의 응답문을 응답 body에 담아 클라이언트에게 전달하도록 수정했습니다.

## 🤔 고민할 점
<!-- ERD 설계에서 어떻게 해야할 지 모르겠습니다. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 인증 실패 및 권한 부족 시 사용자에게 맞춤형 JSON 에러 메시지를 반환하는 기능이 추가되었습니다.

* **버그 수정**
  * 인증 또는 권한 문제 발생 시 보다 명확한 에러 메시지와 상태 코드(401, 403)가 제공됩니다.

* **테스트**
  * 인증 실패 및 권한 거부 상황에서의 에러 응답 동작을 검증하는 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->