### PR TITLE
[#92] 이메일 중복 확인 API RestDocs 추가 및 SecurityConfig 속 URI 수정

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -149,6 +149,8 @@ Access Token은 쿠키로 관리합니다.
 [.lead]
 include::{docdir}/auth.adoc[]
 
+include::{docdir}/member.adoc[]
+
 include::{docdir}/email.adoc[]
 
 include::{docdir}/goal.adoc[]

--- a/src/docs/asciidoc/member.adoc
+++ b/src/docs/asciidoc/member.adoc
@@ -17,7 +17,7 @@ include::{snippets}/member-controller-rest-docs-test/등록되지_않은_이메�
 
 Query Parameters
 
-include::{snippets}/member-controller-rest-docs-test/등록되지_않은_이메일로_이메일_중복_확인_시_성공/Query-parameters.adoc[]
+include::{snippets}/member-controller-rest-docs-test/등록되지_않은_이메일로_이메일_중복_확인_시_성공/query-parameters.adoc[]
 
 ==== Response
 

--- a/src/docs/asciidoc/member.adoc
+++ b/src/docs/asciidoc/member.adoc
@@ -1,0 +1,32 @@
+== 회원 API
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 3
+:sectlinks:
+:snippets: {snippets}
+
+=== 이메일 중복 확인
+
+！ 회원가입에서 이메일 전송 전, 이메일 중복 확인할 때 사용하는 API 입니다.
+
+==== Request
+
+include::{snippets}/member-controller-rest-docs-test/등록되지_않은_이메일로_이메일_중복_확인_시_성공/http-request.adoc[]
+
+Query Parameters
+
+include::{snippets}/member-controller-rest-docs-test/등록되지_않은_이메일로_이메일_중복_확인_시_성공/Query-parameters.adoc[]
+
+==== Response
+
+include::{snippets}/member-controller-rest-docs-test/등록되지_않은_이메일로_이메일_중복_확인_시_성공/http-response.adoc[]
+
+Response Fields
+
+include::{snippets}/member-controller-rest-docs-test/등록되지_않은_이메일로_이메일_중복_확인_시_성공/response-fields.adoc[]
+
+==== 이미 등록된 이메일로 중복 확인 할 경우 (409)
+
+include::{snippets}/member-controller-rest-docs-test/이미_등록된_이메일로_이메일_중복_확인_시_실패/response-body.adoc[]

--- a/src/main/java/tosiltosil/backend/common/auth/config/SecurityConfig.java
+++ b/src/main/java/tosiltosil/backend/common/auth/config/SecurityConfig.java
@@ -51,7 +51,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/v1/auth/reissue").permitAll()
                         .requestMatchers("/api/v1/auth/email/send").permitAll()
                         .requestMatchers("/api/v1/auth/email/verify").permitAll()
-                        .requestMatchers("/api/v1/members/check-email").permitAll()
+                        .requestMatchers("/api/v1/members/email/exists").permitAll()
                         // swagger
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
                         // restdocs

--- a/src/test/java/tosiltosil/backend/module/member/presentation/MemberControllerRestDocsTest.java
+++ b/src/test/java/tosiltosil/backend/module/member/presentation/MemberControllerRestDocsTest.java
@@ -1,0 +1,93 @@
+package tosiltosil.backend.module.member.presentation;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.assertj.MvcTestResult;
+import tosiltosil.backend.common.domain.exception.ConflictException;
+import tosiltosil.backend.module.member.application.MemberService;
+import tosiltosil.backend.support.RestDocsTestSupport;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+
+@WebMvcTest(MemberController.class)
+@SuppressWarnings("NonAsciiCharacters")
+public class MemberControllerRestDocsTest extends RestDocsTestSupport {
+
+    @MockitoBean
+    private MemberService memberService;
+
+    @Test
+    void 등록되지_않은_이메일로_이메일_중복_확인_시_성공() {
+        // given
+        String email = "test@example.com";
+        String type = "LOCAL";
+
+        willDoNothing().given(memberService).validateEmailIsExist(any(String.class), any(String.class));
+
+        // when
+        MvcTestResult testResult = mockMvcTester.get()
+                .uri("/api/v1/members/email/exists?email={email}&type={type}", email, type)
+                .exchange();
+
+        // then
+        assertThat(testResult)
+                .hasStatus(HttpStatus.OK)
+                .bodyJson().isEqualTo("""
+                            {
+                                "status": 200,
+                                "message": "사용 가능한 이메일입니다.",
+                                "data": {}
+                            }
+                        """);
+
+        assertThat(testResult)
+                .apply(documentHandler.document(
+                        queryParameters(
+                                queryParameter("email", "사용자 이메일"),
+                                queryParameter("type", "로그인 타입 (LOCAL / SOCIAL)")
+                                ),
+                        responseFields(
+                                responseField("status", JsonFieldType.NUMBER, "응답 상태 코드", "200"),
+                                responseField("message", JsonFieldType.STRING, "응답 메시지", "사용 가능한 이메일입니다."),
+                                responseField("data", JsonFieldType.OBJECT, "응답 데이터", "{}")
+                        )
+                ));
+    }
+
+    @Test
+    void 이미_등록된_이메일로_이메일_중복_확인_시_실패() {
+        // given
+        String email = "test@example.com";
+        String type = "LOCAL";
+
+        willThrow(new ConflictException("이미 등록된 이메일입니다."))
+                .given(memberService).validateEmailIsExist(any(String.class), any(String.class));
+
+        // when
+        MvcTestResult testResult = mockMvcTester.get()
+                .uri("/api/v1/members/email/exists?email={email}&type={type}", email, type)
+                .exchange();
+
+        // then
+        assertThat(testResult)
+                .hasStatus(HttpStatus.CONFLICT)
+                .bodyJson().isEqualTo("""
+                        {
+                            "status": 409,
+                            "message": "이미 등록된 이메일입니다.",
+                            "errors": []
+                        }
+                        """);
+
+        assertThat(testResult).apply(documentHandler.document());
+    }
+
+}


### PR DESCRIPTION
## 🔢 Issue Number
close #92 

## 👨‍💻 작업 내용
### 1️⃣ MemberControllerRestDocsTest 작성
- 이메일 중복 확인 API를 RestDocs에 추가하기 위해 `MemberControllerRestDocsTest`를 작성했습니다.
- 현재 예외처리 테스트 코드는 **이미 등록된 이메일로 시도할 경우 409**에 대해서만 작성되어 있습니다.

⚠️  현재 잘못된 `LoginType`을 전달할 경우 예외처리가 안 되어 있습니다. 😭 이슈를 새로 파서 진행하겠습니다..!

### 2️⃣ SecurityConfig 내에 이메일 중복 확인 API URI 수정
이전에 수정됐던 API URI를 반영하지 않은 게 발견되어 수정했습니다..! 


## 🤔 고민할 점
<!-- ERD 설계에서 어떻게 해야할 지 모르겠습니다. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 문서화
  - 회원 섹션을 목차에 추가(이메일 섹션 앞에 삽입).
  - 이메일 중복 확인 API 문서 신규 작성(요청/쿼리 파라미터/응답/응답 필드/409 충돌 사례 포함).

- 리팩터
  - 이메일 중복 확인 엔드포인트 경로를 /api/v1/members/email/exists 로 정리하고 공용 접근 허용.

- 테스트
  - 이메일 중복 확인 API에 대한 REST Docs 테스트 추가(성공 200, 이미 등록된 이메일 409 시나리오).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->