### PR TITLE
[#94] 이메일 인증 횟수 Redis TTL 미설정 문제 해결 및 예외처리 로직 추가

### DIFF
--- a/src/docs/asciidoc/email.adoc
+++ b/src/docs/asciidoc/email.adoc
@@ -78,3 +78,7 @@ include::{snippets}/email-controller-rest-docs-test/이메일_인증_시도_횟�
 ==== 인증번호 만료로 인증번호 검증 실패(404)
 
 include::{snippets}/email-controller-rest-docs-test/인증번호_만료로_검증_실패/response-body.adoc[]
+
+==== 인증 번호 이메일을 전송하지 않은 이메일로 인증번호 인증 시도로 검증 실패(404)
+
+include::{snippets}/email-controller-rest-docs-test/인증_번호_전송하지_않은_이메일로_인증번호_시도_시_실패/response-body.adoc[]

--- a/src/main/java/tosiltosil/backend/module/email/application/EmailService.java
+++ b/src/main/java/tosiltosil/backend/module/email/application/EmailService.java
@@ -103,9 +103,9 @@ public class EmailService {
     ) {
         String email = request.email();
 
-        validateIsSentEmail(email);
+        EmailAuthMeta emailAuthMeta = validateIsSentEmail(email);
 
-        int authFailCount = validateAndGetAuthFailCount(email);
+        int authFailCount = validateAndGetAuthFailCount(emailAuthMeta);
 
         validateAuthNumber(email, request.authNumber(), authFailCount);
 
@@ -163,17 +163,17 @@ public class EmailService {
         return authNumber;
     }
 
-    private void validateIsSentEmail(String email) {
+    private EmailAuthMeta validateIsSentEmail(String email) {
         EmailAuthMeta emailAuthMeta = getEmailAuthMeta(email);
 
         if (emailAuthMeta == null) {
             throw new NotFoundException("이메일 인증 요청을 먼저 진행해야 합니다.");
         }
+
+        return emailAuthMeta;
     }
 
-    private int validateAndGetAuthFailCount(String email) {
-        EmailAuthMeta emailAuthMeta = getEmailAuthMeta(email);
-
+    private int validateAndGetAuthFailCount(EmailAuthMeta emailAuthMeta) {
         int authFailCount = emailAuthMeta.authFailCount();
 
         if (authFailCount >= maxAuthAttemptCount) {

--- a/src/main/java/tosiltosil/backend/module/email/application/EmailService.java
+++ b/src/main/java/tosiltosil/backend/module/email/application/EmailService.java
@@ -38,8 +38,13 @@ public class EmailService {
     private final JwtTokenProvider jwtTokenProvider;
     private final JavaMailSender mailSender;
 
+    private static final int INITIAL_SEND_COUNT = 0;
+    private static final int INITIAL_FAIL_COUNT = 0;
     private static final int CODE_LENGTH = 6;
     private static final String EMAIL_TITLE = "토실토실 인증번호";
+
+    @Value("${email.auth.redis-expiration}")
+    private long emailAuthExpiration;
 
     @Value("${email.auth-number.redis-expiration}")
     private long authNumberExpiration;
@@ -77,7 +82,9 @@ public class EmailService {
         String email = request.email();
         EmailAuthPurpose purpose = EmailAuthPurpose.valueOf(request.purpose());
 
-        validateSendAndAuthCount(email);
+        initEmailAttemptsIfAbsent(email);
+
+        validateSendCount(email);
 
         validateEmailIsExistByPurpose(email, purpose);
 
@@ -113,11 +120,21 @@ public class EmailService {
         }
     }
 
-    private void validateSendAndAuthCount(String email) {
+    private void generateEmailAttemptsRedisData(String email) {
+        emailAuthRedisRepository.save(email, INITIAL_SEND_COUNT, INITIAL_FAIL_COUNT, emailAuthExpiration);
+    }
+
+    private void initEmailAttemptsIfAbsent(String email) {
+        if (emailAuthRedisRepository.get(email) == null) {
+            generateEmailAttemptsRedisData(email);
+        }
+    }
+
+    private void validateSendCount(String email) {
         EmailAuthMeta emailAuthMeta = getEmailAuthMeta(email);
 
-        if (emailAuthMeta.sendCount() >= maxSendCount || emailAuthMeta.authFailCount() >= maxAuthAttemptCount) {
-            throw new BadRequestException("일일 이메일 인증 횟수를 초과하였습니다.");
+        if (emailAuthMeta.sendCount() >= maxSendCount) {
+            throw new BadRequestException("일일 전송 제한 횟수를 초과하였습니다.");
         }
     }
 
@@ -156,16 +173,16 @@ public class EmailService {
 
     private void validateAuthNumber(String email, String authNumber, int authFailCount) {
         String savedAuthNumber = authNumberRedisRepository.get(email)
-                .orElseThrow(() -> new NotFoundException("인증 유효 시간이 만료되었거나, 잘못된 인증 요청입니다."));
+                .orElseThrow(() -> new NotFoundException("인증번호 데이터를 찾을 수 없습니다."));
 
         if (!savedAuthNumber.equals(authNumber)) {
-            int failCount = increaseAuthFailCount(email);
-            throw new InvalidEmailCodeException(failCount);
+            increaseAuthFailCount(email);
+            throw new InvalidEmailCodeException(++authFailCount);
         }
     }
 
-    private int increaseAuthFailCount(String email) {
-        return emailAuthRedisRepository.increaseAuthFailCount(email);
+    private void increaseAuthFailCount(String email) {
+        emailAuthRedisRepository.increaseAuthFailCount(email);
     }
 
     private void deleteAuthNumber(String email) {

--- a/src/main/java/tosiltosil/backend/module/email/application/EmailService.java
+++ b/src/main/java/tosiltosil/backend/module/email/application/EmailService.java
@@ -199,13 +199,13 @@ public class EmailService {
                 .orElseThrow(() -> new NotFoundException("인증 유효 시간이 만료되었거나, 잘못된 인증 요청입니다."));
 
         if (!savedAuthNumber.equals(authNumber)) {
-            increaseAuthFailCount(email);
-            throw new InvalidEmailCodeException(++authFailCount);
+            int increasedAuthFailCount = increaseAuthFailCount(email);
+            throw new InvalidEmailCodeException(increasedAuthFailCount);
         }
     }
 
-    private void increaseAuthFailCount(String email) {
-        emailAuthRedisRepository.increaseAuthFailCount(email);
+    private int increaseAuthFailCount(String email) {
+        return emailAuthRedisRepository.increaseAuthFailCount(email);
     }
 
     private void deleteAuthNumber(String email) {

--- a/src/main/java/tosiltosil/backend/module/email/application/EmailService.java
+++ b/src/main/java/tosiltosil/backend/module/email/application/EmailService.java
@@ -84,7 +84,7 @@ public class EmailService {
 
         initEmailAttemptsIfAbsent(email);
 
-        validateSendCount(email);
+        validateCanSendEmail(email);
 
         validateEmailIsExistByPurpose(email, purpose);
 
@@ -101,13 +101,17 @@ public class EmailService {
     public EmailAuthResponse verifyAuthEmail(
             final EmailAuthRequest request
     ) {
-        int authFailCount = validateAndGetAuthFailCount(request.email());
+        String email = request.email();
 
-        validateAuthNumber(request.email(), request.authNumber(), authFailCount);
+        validateIsSentEmail(email);
 
-        deleteAuthNumber(request.email());
+        int authFailCount = validateAndGetAuthFailCount(email);
 
-        return generateTemporaryToken(request.email());
+        validateAuthNumber(email, request.authNumber(), authFailCount);
+
+        deleteAuthNumber(email);
+
+        return generateTemporaryToken(email);
     }
 
     private String loadAuthTemplate(String authNumber) {
@@ -130,12 +134,23 @@ public class EmailService {
         }
     }
 
-    private void validateSendCount(String email) {
+    private void validateSendCount(EmailAuthMeta emailAuthMeta) {
+        if (emailAuthMeta.sendCount() >= maxSendCount) {
+            throw new BadRequestException("일일 이메일 인증 횟수를 초과하였습니다.");
+        }
+    }
+
+    private void validateAuthFailCount(EmailAuthMeta emailAuthMeta) {
+        if (emailAuthMeta.authFailCount() >= maxAuthAttemptCount) {
+            throw new BadRequestException("일일 이메일 인증 횟수를 초과하였습니다.");
+        }
+    }
+
+    private void validateCanSendEmail(String email) {
         EmailAuthMeta emailAuthMeta = getEmailAuthMeta(email);
 
-        if (emailAuthMeta.sendCount() >= maxSendCount) {
-            throw new BadRequestException("일일 전송 제한 횟수를 초과하였습니다.");
-        }
+        validateSendCount(emailAuthMeta);
+        validateAuthFailCount(emailAuthMeta);
     }
 
     private void increaseSendCount(String email) {
@@ -146,6 +161,14 @@ public class EmailService {
         String authNumber = RandomUtils.generateRandomNumberString(CODE_LENGTH);
         authNumberRedisRepository.save(email, authNumber, authNumberExpiration);
         return authNumber;
+    }
+
+    private void validateIsSentEmail(String email) {
+        EmailAuthMeta emailAuthMeta = getEmailAuthMeta(email);
+
+        if (emailAuthMeta == null) {
+            throw new NotFoundException("이메일 인증 요청을 먼저 진행해야 합니다.");
+        }
     }
 
     private int validateAndGetAuthFailCount(String email) {
@@ -173,7 +196,7 @@ public class EmailService {
 
     private void validateAuthNumber(String email, String authNumber, int authFailCount) {
         String savedAuthNumber = authNumberRedisRepository.get(email)
-                .orElseThrow(() -> new NotFoundException("인증번호 데이터를 찾을 수 없습니다."));
+                .orElseThrow(() -> new NotFoundException("인증 유효 시간이 만료되었거나, 잘못된 인증 요청입니다."));
 
         if (!savedAuthNumber.equals(authNumber)) {
             increaseAuthFailCount(email);

--- a/src/main/java/tosiltosil/backend/module/email/infrastructure/EmailAuthRedisRepository.java
+++ b/src/main/java/tosiltosil/backend/module/email/infrastructure/EmailAuthRedisRepository.java
@@ -27,6 +27,11 @@ public class EmailAuthRedisRepository {
 
     public EmailAuthMeta get(String email) {
         String key = createKey(email);
+
+        if (!redisTemplate.hasKey(key)) {
+            return null;
+        }
+
         Map<Object, Object> entries = redisTemplate.opsForHash().entries(key);
 
         int sendCount = parseOrDefault(entries.get(SEND_COUNT_FIELD));

--- a/src/main/java/tosiltosil/backend/module/email/infrastructure/EmailAuthRedisRepository.java
+++ b/src/main/java/tosiltosil/backend/module/email/infrastructure/EmailAuthRedisRepository.java
@@ -50,9 +50,10 @@ public class EmailAuthRedisRepository {
         redisTemplate.opsForHash().increment(key, SEND_COUNT_FIELD, 1);
     }
 
-    public void increaseAuthFailCount(String email) {
+    public int increaseAuthFailCount(String email) {
         String key = createKey(email);
-        redisTemplate.opsForHash().increment(key, AUTH_FAIL_COUNT_FIELD, 1);
+        Long increasedAuthFailCount = redisTemplate.opsForHash().increment(key, AUTH_FAIL_COUNT_FIELD, 1);
+        return increasedAuthFailCount.intValue();
     }
 
     private String createKey(String email) {

--- a/src/main/java/tosiltosil/backend/module/email/infrastructure/EmailAuthRedisRepository.java
+++ b/src/main/java/tosiltosil/backend/module/email/infrastructure/EmailAuthRedisRepository.java
@@ -50,10 +50,9 @@ public class EmailAuthRedisRepository {
         redisTemplate.opsForHash().increment(key, SEND_COUNT_FIELD, 1);
     }
 
-    public int increaseAuthFailCount(String email) {
+    public void increaseAuthFailCount(String email) {
         String key = createKey(email);
         redisTemplate.opsForHash().increment(key, AUTH_FAIL_COUNT_FIELD, 1);
-        return parseOrDefault(redisTemplate.opsForHash().get(key, AUTH_FAIL_COUNT_FIELD));
     }
 
     private String createKey(String email) {

--- a/src/test/java/tosiltosil/backend/module/email/application/EmailServiceTest.java
+++ b/src/test/java/tosiltosil/backend/module/email/application/EmailServiceTest.java
@@ -10,6 +10,7 @@ import tosiltosil.backend.common.domain.exception.BadRequestException;
 import tosiltosil.backend.common.domain.exception.ConflictException;
 import tosiltosil.backend.common.domain.exception.InvalidEmailCodeException;
 import tosiltosil.backend.common.domain.exception.NotFoundException;
+import tosiltosil.backend.module.auth.infrastructure.TemporaryTokenRedisRepository;
 import tosiltosil.backend.module.email.domain.EmailAuthMeta;
 import tosiltosil.backend.module.email.domain.request.EmailAuthRequest;
 import tosiltosil.backend.module.email.domain.request.EmailSendRequest;
@@ -43,6 +44,9 @@ class EmailServiceTest extends IntegrationTestSupport {
     @Autowired
     private AuthNumberRedisRepository authNumberRedisRepository;
 
+    @Autowired
+    private TemporaryTokenRedisRepository temporaryTokenRedisRepository;
+
     @Value("${email.auth.max-send-count}")
     private int maxSendCount;
 
@@ -60,6 +64,7 @@ class EmailServiceTest extends IntegrationTestSupport {
     void tearDown() {
         emailAuthRedisRepository.delete(email);
         authNumberRedisRepository.delete(email);
+        temporaryTokenRedisRepository.delete(email);
     }
 
     @Test
@@ -93,7 +98,7 @@ class EmailServiceTest extends IntegrationTestSupport {
     @Test
     void 이미_가입된_이메일로_회원가입용_이메일_인증_시도하여_전송_실패() {
         // given
-        String duplicatedEmail = "duplicated@example.com";
+        String duplicatedEmail = "test@example.com";
         EmailSendRequest request = new EmailSendRequest(duplicatedEmail, SIGN_UP.name());
 
         doThrow(new ConflictException("이미 등록된 이메일입니다."))

--- a/src/test/java/tosiltosil/backend/module/email/application/EmailServiceTest.java
+++ b/src/test/java/tosiltosil/backend/module/email/application/EmailServiceTest.java
@@ -184,6 +184,10 @@ class EmailServiceTest extends IntegrationTestSupport {
     void 인증번호_유효_시간_만료_및_Redis_데이터가_존재하지않아_검증_실패() {
         // given
         String authNumber = "123456";
+
+        // 인증번호 이메일을 전송했음을 나타냄
+        emailAuthRedisRepository.save(email, 1, 0, 100L);
+
         EmailAuthRequest request = new EmailAuthRequest(email, authNumber);
 
         // when & then

--- a/src/test/java/tosiltosil/backend/module/email/application/EmailServiceTest.java
+++ b/src/test/java/tosiltosil/backend/module/email/application/EmailServiceTest.java
@@ -197,4 +197,18 @@ class EmailServiceTest extends IntegrationTestSupport {
                 .isInstanceOf(NotFoundException.class)
                 .hasMessage("인증 유효 시간이 만료되었거나, 잘못된 인증 요청입니다.");
     }
+
+    @Test
+    void 인증_번호_전송하지_않은_이메일로_인증번호_시도_시_실패() {
+        // given
+        String authNumber = "123456";
+        EmailAuthRequest request = new EmailAuthRequest(email, authNumber);
+
+        // when & then
+        assertThat(authNumberRedisRepository.get(email)).isEmpty();
+
+        assertThatThrownBy(() -> emailService.verifyAuthEmail(request))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage("이메일 인증 요청을 먼저 진행해야 합니다.");
+    }
 }

--- a/src/test/java/tosiltosil/backend/module/email/presentation/EmailControllerRestDocsTest.java
+++ b/src/test/java/tosiltosil/backend/module/email/presentation/EmailControllerRestDocsTest.java
@@ -457,4 +457,38 @@ class EmailControllerRestDocsTest extends RestDocsTestSupport {
         assertThat(testResult)
                 .apply(documentHandler.document());
     }
+
+    @Test
+    void 인증_번호_전송하지_않은_이메일로_인증번호_시도_시_실패() {
+        // given
+        String request = """
+                {
+                    "email": "test@example.com",
+                    "authNumber": "125526"
+                }
+                """;
+
+        given(emailService.verifyAuthEmail(any(EmailAuthRequest.class)))
+                .willThrow(new NotFoundException("이메일 인증 요청을 먼저 진행해야 합니다."));
+
+        // when
+        MvcTestResult testResult = mockMvcTester.post()
+                .uri("/api/v1/auth/email/verify")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(request)
+                .exchange();
+
+        // then
+        assertThat(testResult)
+                .bodyJson().isEqualTo("""
+                            {
+                                "status": 404,
+                                "message": "이메일 인증 요청을 먼저 진행해야 합니다.",
+                                "errors": []
+                            }
+                        """);
+
+        assertThat(testResult)
+                .apply(documentHandler.document());
+    }
 }


### PR DESCRIPTION
## 🔢 Issue Number
close #94 

## 👨‍💻 작업 내용
### 1️⃣ 이메일 인증 시도 횟수 Redis 저장 시, TTL이 설정되도록 수정

코드가 누락되어 생긴 문제인 줄 알았는데, `save()` 메서드가 실제로 실행되지 않아 발생하는 문제였습니다.

이전에는 `EmailAuthRedisRepository.get({key})` 를 호출 했을 때, null 값이면 `save()` 메서드가 호출되도록 로직을 구성했는데,
존재하지 않는 redis 데이터를 조회할 때, 자동으로 데이터를 생성하기 때문에 save() 메서드가 호출되지 않았습니다.

따라서 RedisRepository.get() 메서드 내부에 특정 key 값에 대한 데이터가 존재하지 않으면 null 을 반환하도록 수정하여 이 문제를 해결했습니다.

``` java
public EmailAuthMeta get(String email) {
        String key = createKey(email);

        // key에 해당하는 redis 데이터가 없으면 null 반환
        if (!redisTemplate.hasKey(key)) {
            return null;
        }

        Map<Object, Object> entries = redisTemplate.opsForHash().entries(key);

        int sendCount = parseOrDefault(entries.get(SEND_COUNT_FIELD));
        int authFailCount = parseOrDefault(entries.get(AUTH_FAIL_COUNT_FIELD));

        return new EmailAuthMeta(sendCount, authFailCount);
    }
```

### 2️⃣ 예외처리 추가 및 테스트 코드 작성

요구사항을 반영하지 않은 예외처리를 일부 발견하여 추가하였습니다.

- 인증 이메일을 전송하지 않았는데, 인증번호 인증을 시도할 경우 예외처리 추가
- 인증번호 인증 시도 횟수가 초과 됐을 경우, 이메일이 전송되지 않도록 예외처리 추가

## 🤔 고민할 점
<!-- ERD 설계에서 어떻게 해야할 지 모르겠습니다. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 이메일별 발송·실패 시도 카운트 도입으로 하루별 인증 시도 제한이 적용되어 인증 시도 관리가 강화되었습니다.
- Bug Fixes
  - 인증 요청이 없는 이메일로 인증번호 검증 시 404 응답과 안내 메시지("이메일 인증 요청을 먼저 진행해야 합니다.")가 반환됩니다.
- Documentation
  - 인증번호 미전송 이메일 검증 실패(404) 사례와 응답 예시 문서 추가.
- Tests
  - 해당 404 시나리오에 대한 서비스 및 REST Docs 테스트 추가 및 보강.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->