### PR TITLE
[#98] staging 서버 cloud환경으로 이전

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -61,19 +61,6 @@ jobs:
           token: ${{ secrets.HS_TOKEN }}
           submodules: recursive
 
-      - name: Copy Config Files to Staging Server
-        uses: appleboy/scp-action@master
-        with:
-          host: ${{ secrets.LOCAL_SERVER_HOST }}
-          username: ubuntu
-          key: ${{ secrets.LOCAL_SERVER_SSH_KEY }}
-          port: ${{ secrets.LOCAL_SERVER_PORT }}
-          passphrase: ${{ secrets.LOCAL_SERVER_SSH_PASSPHRASE }}
-          source: "src/main/resources/tosiltosil-yml/logback-stag.xml, src/main/resources/tosiltosil-yml/application-stag.yml"
-          target: /home/ubuntu/tosiltosil/
-          strip_components: 4  # This removes 4 directory levels (src/main/resources/tosiltosil-yml/)
-          overwrite: true
-
       - name: Deploy to Staging Server
         uses: appleboy/ssh-action@master
         with:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     container: ghcr.io/railwayapp/cli:latest
     env:
-      SVC_ID: my-service-id
+      SVC_ID: 015b5772-c4f6-4190-838f-edd707e75da4
       RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -79,6 +79,6 @@ jobs:
             echo "🏃 Starting the Spring Boot using Docker"
             docker run -it -d -p 8080:8080 \
             --name springboot \
-            -e SPRING_PROFILES_ACTIVE=dev \
+            -e SPRING_PROFILES_ACTIVE=stag \
             --network application_app-network \
             pshsh910/tosiltosil:latest

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -65,7 +65,7 @@ jobs:
         uses: appleboy/ssh-action@master
         with:
           host: ${{ secrets.STAGING_SERVER_HOST }}
-          username: ubuntu
+          username: ${{ secrets.STAGING_SERVER_USERNAME }}
           key: ${{ secrets.STAGING_SERVER_SSH_KEY }}
           port: ${{ secrets.STAGING_SERVER_PORT }}
           script: |

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,101 +2,15 @@ name: backend-cd
 
 on:
   push:
-    branches: [ "develop" ]
+    branches: [ "feature/#98-deploy" ]
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-
-    services:
-      redis:
-        image: redis:latest
-        ports:
-          - 6379:6379
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.HS_TOKEN }}
-          submodules: recursive
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v4
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-
-      - name: Gradle Caching
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-
-      - name: Build with Gradle
-        run: |
-            chmod +x gradlew
-            ./gradlew clean bootJar --no-daemon --stacktrace --info
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: pshsh910
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
-
-      - name: Build and Push Docker image
-        run: |
-          docker build -t pshsh910/tosiltosil:latest .
-          docker push pshsh910/tosiltosil:latest
-
   deploy:
-    needs: build
     runs-on: ubuntu-latest
+    container: ghcr.io/railwayapp/cli:latest
+    env:
+      SVC_ID: my-service-id
+      RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.HS_TOKEN }}
-          submodules: recursive
-
-      - name: Copy Config Files to Staging Server
-        uses: appleboy/scp-action@master
-        with:
-          host: ${{ secrets.LOCAL_SERVER_HOST }}
-          username: ubuntu
-          key: ${{ secrets.LOCAL_SERVER_SSH_KEY }}
-          port: ${{ secrets.LOCAL_SERVER_PORT }}
-          passphrase: ${{ secrets.LOCAL_SERVER_SSH_PASSPHRASE }}
-          source: "src/main/resources/tosiltosil-yml/logback-stag.xml, src/main/resources/tosiltosil-yml/application-stag.yml"
-          target: /home/ubuntu/tosiltosil/
-          strip_components: 4  # This removes 4 directory levels (src/main/resources/tosiltosil-yml/)
-          overwrite: true
-
-      - name: Deploy to Staging Server
-        uses: appleboy/ssh-action@master
-        with:
-          host: ${{ secrets.LOCAL_SERVER_HOST }}
-          username: ubuntu
-          key: ${{ secrets.LOCAL_SERVER_SSH_KEY }}
-          port: ${{ secrets.LOCAL_SERVER_PORT }}
-          passphrase: ${{ secrets.LOCAL_SERVER_SSH_PASSPHRASE }}
-          script: |
-            echo "✅ Checking if the springboot container is running"
-            docker stop springboot || true
-            docker rm springboot || true
-            
-            echo "📥 Pulling latest image"
-            docker pull pshsh910/tosiltosil:latest
-            
-            echo "🏃 Starting the Spring Boot using Docker"
-            docker run -it -d -p 8080:8080 \
-            --name springboot \
-            -e SPRING_PROFILES_ACTIVE=stag \
-            -e logging.config=file:/app/logback-stag.xml \
-            -e spring.config.location=/app/application-stag.yml \
-            -v /home/ubuntu/tosiltosil/logback-stag.xml:/app/logback-stag.xml \
-            -v /home/ubuntu/tosiltosil/application-stag.yml:/app/application-stag.yml \
-            --network web \
-            pshsh910/tosiltosil:latest
+      - uses: actions/checkout@v3
+      - run: railway up --service=${{ env.SVC_ID }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -79,6 +79,6 @@ jobs:
             echo "🏃 Starting the Spring Boot using Docker"
             docker run -it -d -p 8080:8080 \
             --name springboot \
-            -e SPRING_PROFILES_ACTIVE=stag \
+            -e SPRING_PROFILES_ACTIVE=dev \
             --network application_app-network \
             pshsh910/tosiltosil:latest

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -80,5 +80,5 @@ jobs:
             docker run -it -d -p 8080:8080 \
             --name springboot \
             -e SPRING_PROFILES_ACTIVE=stag \
-            --network app-network \
+            --network application_app-network \
             pshsh910/tosiltosil:latest

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,7 +2,7 @@ name: backend-cd
 
 on:
   push:
-    branches: [ "feature/#98-deploy" ]
+    branches: [ "develop" ]
 
 jobs:
   build:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,12 +5,93 @@ on:
     branches: [ "feature/#98-deploy" ]
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
-    container: ghcr.io/railwayapp/cli:latest
-    env:
-      SVC_ID: 015b5772-c4f6-4190-838f-edd707e75da4
-      RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+
+    services:
+      redis:
+        image: redis:latest
+        ports:
+          - 6379:6379
+
     steps:
-      - uses: actions/checkout@v3
-      - run: railway up --service=${{ env.SVC_ID }}
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.HS_TOKEN }}
+          submodules: recursive
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Gradle Caching
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Build with Gradle
+        run: |
+          chmod +x gradlew
+          ./gradlew clean bootJar --no-daemon --stacktrace --info
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: pshsh910
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Build and Push Docker image
+        run: |
+          docker build -t pshsh910/tosiltosil:latest .
+          docker push pshsh910/tosiltosil:latest
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.HS_TOKEN }}
+          submodules: recursive
+
+      - name: Copy Config Files to Staging Server
+        uses: appleboy/scp-action@master
+        with:
+          host: ${{ secrets.LOCAL_SERVER_HOST }}
+          username: ubuntu
+          key: ${{ secrets.LOCAL_SERVER_SSH_KEY }}
+          port: ${{ secrets.LOCAL_SERVER_PORT }}
+          passphrase: ${{ secrets.LOCAL_SERVER_SSH_PASSPHRASE }}
+          source: "src/main/resources/tosiltosil-yml/logback-stag.xml, src/main/resources/tosiltosil-yml/application-stag.yml"
+          target: /home/ubuntu/tosiltosil/
+          strip_components: 4  # This removes 4 directory levels (src/main/resources/tosiltosil-yml/)
+          overwrite: true
+
+      - name: Deploy to Staging Server
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.STAGING_SERVER_HOST }}
+          username: ubuntu
+          key: ${{ secrets.STAGING_SERVER_SSH_KEY }}
+          port: ${{ secrets.STAGING_SERVER_PORT }}
+          script: |
+            echo "✅ Checking if the springboot container is running"
+            docker stop springboot || true
+            docker rm springboot || true
+            
+            echo "📥 Pulling latest image"
+            docker pull pshsh910/tosiltosil:latest
+            
+            echo "🏃 Starting the Spring Boot using Docker"
+            docker run -it -d -p 8080:8080 \
+            --name springboot \
+            -e SPRING_PROFILES_ACTIVE=stag \
+            --network app-network \
+            pshsh910/tosiltosil:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY gradle gradle
 COPY build.gradle settings.gradle gradlew ./
 COPY src src
 RUN chmod +x gradlew
-RUN ./gradlew build -x test
+RUN ./gradlew build
 
 # deploy stage
 FROM openjdk:17-jdk-slim

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,15 @@
-FROM openjdk:17-slim
-COPY build/libs/*.jar app.jar
-ARG SPRING_PROFILES_ACTIVE
-ENV SPRING_PROFILES_ACTIVE $SPRING_PROFILES_ACTIVE
+# build stage
+FROM gradle:7.6-jdk17 AS build
+WORKDIR /app
+COPY gradle gradle
+COPY build.gradle settings.gradle gradlew ./
+COPY src src
+RUN chmod +x gradlew
+RUN ./gradlew build -x test
+
+# deploy stage
+FROM openjdk:17-jdk-slim
+WORKDIR /app
+COPY --from=build /app/build/libs/*.jar app.jar
 EXPOSE 8080
-ENTRYPOINT ["java", "-jar", "app.jar"]
+ENTRYPOINT ["java", "-jar", "-Dserver.port=${PORT}", "app.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,6 @@
-# build stage
-FROM gradle:7.6-jdk17 AS build
-WORKDIR /app
-COPY gradle gradle
-COPY build.gradle settings.gradle gradlew ./
-COPY src src
-RUN chmod +x gradlew
-RUN ./gradlew build
-
-# deploy stage
-FROM openjdk:17-jdk-slim
-WORKDIR /app
-COPY --from=build /app/build/libs/*.jar app.jar
+FROM openjdk:17-slim
+COPY build/libs/*.jar app.jar
+ARG SPRING_PROFILES_ACTIVE
+ENV SPRING_PROFILES_ACTIVE $SPRING_PROFILES_ACTIVE
 EXPOSE 8080
-ENTRYPOINT ["java", "-jar", "-Dserver.port=${PORT}", "app.jar"]
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/src/main/java/tosiltosil/backend/common/auth/config/SecurityConfig.java
+++ b/src/main/java/tosiltosil/backend/common/auth/config/SecurityConfig.java
@@ -45,6 +45,8 @@ public class SecurityConfig {
                 .sessionManagement(it -> it.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+                        // actuator health/info endpoints (allow unauthenticated for health checks)
+                        .requestMatchers("/actuator/health", "/actuator/health/**", "/actuator/prometheus").permitAll()
                         // auth
                         .requestMatchers("/api/v1/auth/signup/local").permitAll()
                         .requestMatchers("/api/v1/auth/login/local").permitAll()


### PR DESCRIPTION
## 🔢 Issue Number
<!-- close #{issue-number} when solved issue -->
<!-- relates to #{issue-number} when just link without closing -->
close #98 

## 👨‍💻 작업 내용
<!-- 회원 비밀번호 저장 암호화 알고리즘을 수정했습니다. --> 
### staging 서버 이전
기존에 local server로 구동하던 것을 Oracle Cloud Free Tier instance 2개로 활용하여 이전하였습니다.

서버 코드는 달라진 점이 없으며, db-instance, app-instance 이렇게 2개로 나누어서 구동한다는 차이점이 있습니다.

서버 구성 및 접속 방법은 노션 및 메신저를 통해 자세히 전달해드리겠습니다!

‼️ commit이 조금 더럽습니다.. 빨리 한다는 생각에 commit history를 생각하지 못했습니다.. 죄송합니다.. 

## 🤔 고민할 점
<!-- ERD 설계에서 어떻게 해야할 지 모르겠습니다. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - /actuator/health 및 /actuator/prometheus 엔드포인트에 인증 없이 접근 가능해져 모니터링/헬스 체크가 용이해졌습니다.
- Chores
  - CD 파이프라인을 스테이징 배포 대상으로 정비하고 구성 파일 복사 단계를 제거했습니다.
  - Docker 실행 옵션을 단순화(프로필 지정 및 네트워크 변경)하고 연결 비밀값을 스테이징용으로 업데이트했습니다.
  - 워크플로 포맷을 소폭 정리했습니다.
  - 리소스 서브모듈을 최신 커밋으로 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->