### PR TITLE
[#91] EmailService와 EmailAuthService 로직 분리

### DIFF
--- a/src/main/java/tosiltosil/backend/module/auth/application/EmailAuthService.java
+++ b/src/main/java/tosiltosil/backend/module/auth/application/EmailAuthService.java
@@ -1,0 +1,195 @@
+package tosiltosil.backend.module.auth.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Service;
+import tosiltosil.backend.common.auth.JwtTokenProvider;
+import tosiltosil.backend.common.domain.exception.InvalidEmailCodeException;
+import tosiltosil.backend.common.domain.exception.NotFoundException;
+import tosiltosil.backend.common.domain.exception.TooManyRequestsException;
+import tosiltosil.backend.common.util.RandomUtils;
+import tosiltosil.backend.module.email.application.EmailService;
+import tosiltosil.backend.module.auth.domain.response.email.EmailAuthMeta;
+import tosiltosil.backend.module.auth.domain.request.email.EmailAuthRequest;
+import tosiltosil.backend.module.auth.domain.request.email.EmailSendRequest;
+import tosiltosil.backend.module.auth.domain.response.email.EmailAuthResponse;
+import tosiltosil.backend.module.auth.domain.response.email.EmailSendResponse;
+import tosiltosil.backend.module.auth.domain.value.EmailAuthPurpose;
+import tosiltosil.backend.module.auth.infrastructure.AuthNumberRedisRepository;
+import tosiltosil.backend.module.auth.infrastructure.EmailAuthRedisRepository;
+import tosiltosil.backend.module.member.application.MemberService;
+
+import java.nio.charset.StandardCharsets;
+
+import static tosiltosil.backend.module.auth.domain.value.EmailAuthPurpose.FORGOT_PASSWORD;
+import static tosiltosil.backend.module.member.domain.value.LoginType.LOCAL;
+
+@Service
+@RequiredArgsConstructor
+public class EmailAuthService {
+
+    private static final int INITIAL_SEND_COUNT = 0;
+    private static final int INITIAL_FAIL_COUNT = 0;
+    private static final int CODE_LENGTH = 6;
+    private static final String EMAIL_TITLE = "토실토실 인증번호";
+
+    @Value("${email.auth.redis-expiration}")
+    private long emailAuthExpiration;
+
+    @Value("${email.auth-number.redis-expiration}")
+    private long authNumberExpiration;
+
+    @Value("${email.auth.max-send-count}")
+    private int maxSendCount;
+
+    @Value("${email.auth.max-attempt-count}")
+    private int maxAuthAttemptCount;
+
+    private final MemberService memberService;
+    private final EmailService emailService;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final AuthNumberRedisRepository authNumberRedisRepository;
+    private final EmailAuthRedisRepository emailAuthRedisRepository;
+
+    public EmailSendResponse sendAuthEmail(
+            final EmailSendRequest request
+    ) {
+        String email = request.email();
+        EmailAuthPurpose purpose = EmailAuthPurpose.valueOf(request.purpose());
+
+        initEmailAttemptsIfAbsent(email);
+
+        validateCanSendEmail(email);
+
+        validateEmailIsExistByPurpose(email, purpose);
+
+        String authNumber = generateAndSaveAuthNumber(email);
+
+        String content = loadAuthTemplate(authNumber);
+        emailService.sendEmail(email, EMAIL_TITLE, content);
+
+        increaseSendCount(email);
+
+        return EmailSendResponse.of(email);
+    }
+
+    public EmailAuthResponse verifyAuthEmail(
+            final EmailAuthRequest request
+    ) {
+        String email = request.email();
+
+        EmailAuthMeta emailAuthMeta = validateIsSentEmail(email);
+
+        int authFailCount = validateAndGetAuthFailCount(emailAuthMeta);
+
+        validateAuthNumber(email, request.authNumber(), authFailCount);
+
+        deleteAuthNumber(email);
+
+        return generateTemporaryToken(email);
+    }
+
+    private String loadAuthTemplate(String authNumber) {
+        try {
+            ClassPathResource resource = new ClassPathResource("templates/email-auth-template.html");
+            String template = new String(resource.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+            return template.replace("{{authNumber}}", authNumber);
+        } catch (Exception e) {
+            throw new RuntimeException("템플릿을 가져올 수 없습니다.", e);
+        }
+    }
+
+    private void generateEmailAttemptsRedisData(String email) {
+        emailAuthRedisRepository.save(email, INITIAL_SEND_COUNT, INITIAL_FAIL_COUNT, emailAuthExpiration);
+    }
+
+    private void initEmailAttemptsIfAbsent(String email) {
+        if (emailAuthRedisRepository.get(email) == null) {
+            generateEmailAttemptsRedisData(email);
+        }
+    }
+
+    private void validateSendCount(EmailAuthMeta emailAuthMeta) {
+        if (emailAuthMeta.sendCount() >= maxSendCount) {
+            throw new TooManyRequestsException("일일 이메일 인증 횟수를 초과하였습니다.");
+        }
+    }
+
+    private void validateAuthFailCount(EmailAuthMeta emailAuthMeta) {
+        if (emailAuthMeta.authFailCount() >= maxAuthAttemptCount) {
+            throw new TooManyRequestsException("일일 이메일 인증 횟수를 초과하였습니다.");
+        }
+    }
+
+    private void validateCanSendEmail(String email) {
+        EmailAuthMeta emailAuthMeta = getEmailAuthMeta(email);
+
+        validateSendCount(emailAuthMeta);
+        validateAuthFailCount(emailAuthMeta);
+    }
+
+    private void increaseSendCount(String email) {
+        emailAuthRedisRepository.increaseSendCount(email);
+    }
+
+    private String generateAndSaveAuthNumber(String email) {
+        String authNumber = RandomUtils.generateRandomNumberString(CODE_LENGTH);
+        authNumberRedisRepository.save(email, authNumber, authNumberExpiration);
+        return authNumber;
+    }
+
+    private EmailAuthMeta validateIsSentEmail(String email) {
+        EmailAuthMeta emailAuthMeta = getEmailAuthMeta(email);
+
+        if (emailAuthMeta == null) {
+            throw new NotFoundException("이메일 인증 요청을 먼저 진행해야 합니다.");
+        }
+
+        return emailAuthMeta;
+    }
+
+    private int validateAndGetAuthFailCount(EmailAuthMeta emailAuthMeta) {
+        int authFailCount = emailAuthMeta.authFailCount();
+
+        if (authFailCount >= maxAuthAttemptCount) {
+            throw new TooManyRequestsException("일일 이메일 인증 횟수를 초과하였습니다.");
+        }
+        return authFailCount;
+    }
+
+    private EmailAuthMeta getEmailAuthMeta(String email) {
+        return emailAuthRedisRepository.get(email);
+    }
+
+    private void validateEmailIsExistByPurpose(String email, EmailAuthPurpose purpose) {
+        if (purpose.equals(FORGOT_PASSWORD)) {
+            memberService.validateEmailIsExistForPasswordReset(email, LOCAL.name());
+        } else {
+            memberService.validateEmailIsExist(email, LOCAL.name());
+        }
+    }
+
+    private void validateAuthNumber(String email, String authNumber, int authFailCount) {
+        String savedAuthNumber = authNumberRedisRepository.get(email)
+                .orElseThrow(() -> new NotFoundException("인증 유효 시간이 만료되었거나, 잘못된 인증 요청입니다."));
+
+        if (!savedAuthNumber.equals(authNumber)) {
+            int increasedAuthFailCount = increaseAuthFailCount(email);
+            throw new InvalidEmailCodeException(increasedAuthFailCount);
+        }
+    }
+
+    private int increaseAuthFailCount(String email) {
+        return emailAuthRedisRepository.increaseAuthFailCount(email);
+    }
+
+    private void deleteAuthNumber(String email) {
+        authNumberRedisRepository.delete(email);
+    }
+
+    private EmailAuthResponse generateTemporaryToken(String email) {
+        String temporaryToken = jwtTokenProvider.createTemporaryToken(email);
+        return EmailAuthResponse.of(temporaryToken);
+    }
+}

--- a/src/main/java/tosiltosil/backend/module/auth/domain/request/email/EmailAuthRequest.java
+++ b/src/main/java/tosiltosil/backend/module/auth/domain/request/email/EmailAuthRequest.java
@@ -1,4 +1,4 @@
-package tosiltosil.backend.module.email.domain.request;
+package tosiltosil.backend.module.auth.domain.request.email;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;

--- a/src/main/java/tosiltosil/backend/module/auth/domain/request/email/EmailSendRequest.java
+++ b/src/main/java/tosiltosil/backend/module/auth/domain/request/email/EmailSendRequest.java
@@ -1,9 +1,9 @@
-package tosiltosil.backend.module.email.domain.request;
+package tosiltosil.backend.module.auth.domain.request.email;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import tosiltosil.backend.common.domain.validator.IsEnum;
-import tosiltosil.backend.module.email.domain.value.EmailAuthPurpose;
+import tosiltosil.backend.module.auth.domain.value.EmailAuthPurpose;
 
 public record EmailSendRequest(
         @NotBlank(message="이메일을 입력해주세요.")

--- a/src/main/java/tosiltosil/backend/module/auth/domain/response/email/EmailAuthMeta.java
+++ b/src/main/java/tosiltosil/backend/module/auth/domain/response/email/EmailAuthMeta.java
@@ -1,4 +1,4 @@
-package tosiltosil.backend.module.email.domain;
+package tosiltosil.backend.module.auth.domain.response.email;
 
 import java.io.Serializable;
 

--- a/src/main/java/tosiltosil/backend/module/auth/domain/response/email/EmailAuthResponse.java
+++ b/src/main/java/tosiltosil/backend/module/auth/domain/response/email/EmailAuthResponse.java
@@ -1,4 +1,4 @@
-package tosiltosil.backend.module.email.domain.response;
+package tosiltosil.backend.module.auth.domain.response.email;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 

--- a/src/main/java/tosiltosil/backend/module/auth/domain/response/email/EmailSendResponse.java
+++ b/src/main/java/tosiltosil/backend/module/auth/domain/response/email/EmailSendResponse.java
@@ -1,4 +1,4 @@
-package tosiltosil.backend.module.email.domain.response;
+package tosiltosil.backend.module.auth.domain.response.email;
 
 public record EmailSendResponse(
         String email

--- a/src/main/java/tosiltosil/backend/module/auth/domain/value/EmailAuthPurpose.java
+++ b/src/main/java/tosiltosil/backend/module/auth/domain/value/EmailAuthPurpose.java
@@ -1,4 +1,4 @@
-package tosiltosil.backend.module.email.domain.value;
+package tosiltosil.backend.module.auth.domain.value;
 
 public enum EmailAuthPurpose {
     SIGN_UP,

--- a/src/main/java/tosiltosil/backend/module/auth/infrastructure/AuthNumberRedisRepository.java
+++ b/src/main/java/tosiltosil/backend/module/auth/infrastructure/AuthNumberRedisRepository.java
@@ -1,4 +1,4 @@
-package tosiltosil.backend.module.email.infrastructure;
+package tosiltosil.backend.module.auth.infrastructure;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;

--- a/src/main/java/tosiltosil/backend/module/auth/infrastructure/EmailAuthRedisRepository.java
+++ b/src/main/java/tosiltosil/backend/module/auth/infrastructure/EmailAuthRedisRepository.java
@@ -1,9 +1,9 @@
-package tosiltosil.backend.module.email.infrastructure;
+package tosiltosil.backend.module.auth.infrastructure;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Repository;
-import tosiltosil.backend.module.email.domain.EmailAuthMeta;
+import tosiltosil.backend.module.auth.domain.response.email.EmailAuthMeta;
 
 import java.util.Map;
 import java.util.concurrent.TimeUnit;

--- a/src/main/java/tosiltosil/backend/module/auth/presentation/EmailAuthController.java
+++ b/src/main/java/tosiltosil/backend/module/auth/presentation/EmailAuthController.java
@@ -1,4 +1,4 @@
-package tosiltosil.backend.module.email.presentation;
+package tosiltosil.backend.module.auth.presentation;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -8,18 +8,18 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import tosiltosil.backend.common.util.CookieUtil;
 import tosiltosil.backend.common.web.response.Response;
-import tosiltosil.backend.module.email.application.EmailService;
-import tosiltosil.backend.module.email.domain.request.EmailAuthRequest;
-import tosiltosil.backend.module.email.domain.request.EmailSendRequest;
-import tosiltosil.backend.module.email.domain.response.EmailAuthResponse;
-import tosiltosil.backend.module.email.domain.response.EmailSendResponse;
+import tosiltosil.backend.module.auth.application.EmailAuthService;
+import tosiltosil.backend.module.auth.domain.request.email.EmailAuthRequest;
+import tosiltosil.backend.module.auth.domain.request.email.EmailSendRequest;
+import tosiltosil.backend.module.auth.domain.response.email.EmailAuthResponse;
+import tosiltosil.backend.module.auth.domain.response.email.EmailSendResponse;
 
 @RestController
 @RequestMapping("/api/v1/auth/email")
 @RequiredArgsConstructor
-public class EmailController {
+public class EmailAuthController {
 
-    private final EmailService emailService;
+    private final EmailAuthService emailAuthService;
     private final CookieUtil cookieUtil;
 
     @PostMapping("/send")
@@ -27,7 +27,7 @@ public class EmailController {
     public Response<EmailSendResponse> sendEmail(
             @Valid @RequestBody final EmailSendRequest request
     ) {
-        EmailSendResponse response = emailService.sendAuthEmail(request);
+        EmailSendResponse response = emailAuthService.sendAuthEmail(request);
         return Response.ok("정상적으로 이메일을 전송했습니다.", response);
     }
 
@@ -36,7 +36,7 @@ public class EmailController {
     public ResponseEntity<Response<?>> verifyEmailAuth(
             @Valid @RequestBody final EmailAuthRequest request
     ) {
-        EmailAuthResponse response = emailService.verifyAuthEmail(request);
+        EmailAuthResponse response = emailAuthService.verifyAuthEmail(request);
         String temporaryToken = response.temporaryToken();
 
         HttpHeaders headers = cookieUtil.generateTemporaryTokenCookies(temporaryToken);

--- a/src/main/java/tosiltosil/backend/module/email/application/EmailService.java
+++ b/src/main/java/tosiltosil/backend/module/email/application/EmailService.java
@@ -2,58 +2,17 @@ package tosiltosil.backend.module.email.application;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.io.ClassPathResource;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.mail.javamail.MimeMessagePreparator;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
-import tosiltosil.backend.common.auth.JwtTokenProvider;
-import tosiltosil.backend.common.domain.exception.InvalidEmailCodeException;
-import tosiltosil.backend.common.domain.exception.NotFoundException;
-import tosiltosil.backend.common.domain.exception.TooManyRequestsException;
-import tosiltosil.backend.common.util.RandomUtils;
-import tosiltosil.backend.module.email.domain.EmailAuthMeta;
-import tosiltosil.backend.module.email.domain.request.EmailAuthRequest;
-import tosiltosil.backend.module.email.domain.request.EmailSendRequest;
-import tosiltosil.backend.module.email.domain.response.EmailAuthResponse;
-import tosiltosil.backend.module.email.domain.response.EmailSendResponse;
-import tosiltosil.backend.module.email.domain.value.EmailAuthPurpose;
-import tosiltosil.backend.module.email.infrastructure.AuthNumberRedisRepository;
-import tosiltosil.backend.module.email.infrastructure.EmailAuthRedisRepository;
-import tosiltosil.backend.module.member.application.MemberService;
-
-import java.nio.charset.StandardCharsets;
-
-import static tosiltosil.backend.module.email.domain.value.EmailAuthPurpose.FORGOT_PASSWORD;
-import static tosiltosil.backend.module.member.domain.value.LoginType.LOCAL;
 
 @Service
 @RequiredArgsConstructor
 public class EmailService {
 
-    private final AuthNumberRedisRepository authNumberRedisRepository;
-    private final EmailAuthRedisRepository emailAuthRedisRepository;
-    private final MemberService memberService;
-    private final JwtTokenProvider jwtTokenProvider;
     private final JavaMailSender mailSender;
-
-    private static final int INITIAL_SEND_COUNT = 0;
-    private static final int INITIAL_FAIL_COUNT = 0;
-    private static final int CODE_LENGTH = 6;
-    private static final String EMAIL_TITLE = "토실토실 인증번호";
-
-    @Value("${email.auth.redis-expiration}")
-    private long emailAuthExpiration;
-
-    @Value("${email.auth-number.redis-expiration}")
-    private long authNumberExpiration;
-
-    @Value("${email.auth.max-send-count}")
-    private int maxSendCount;
-
-    @Value("${email.auth.max-attempt-count}")
-    private int maxAuthAttemptCount;
 
     @Value("${spring.mail.username}")
     private String id;
@@ -74,146 +33,5 @@ public class EmailService {
         } catch(Exception e) {
             throw new RuntimeException("이메일 전송에 실패하였습니다.", e);
         }
-    }
-
-    public EmailSendResponse sendAuthEmail(
-            final EmailSendRequest request
-    ) {
-        String email = request.email();
-        EmailAuthPurpose purpose = EmailAuthPurpose.valueOf(request.purpose());
-
-        initEmailAttemptsIfAbsent(email);
-
-        validateCanSendEmail(email);
-
-        validateEmailIsExistByPurpose(email, purpose);
-
-        String authNumber = generateAndSaveAuthNumber(email);
-
-        String content = loadAuthTemplate(authNumber);
-        sendEmail(email, EMAIL_TITLE, content);
-
-        increaseSendCount(email);
-
-        return EmailSendResponse.of(email);
-    }
-
-    public EmailAuthResponse verifyAuthEmail(
-            final EmailAuthRequest request
-    ) {
-        String email = request.email();
-
-        EmailAuthMeta emailAuthMeta = validateIsSentEmail(email);
-
-        int authFailCount = validateAndGetAuthFailCount(emailAuthMeta);
-
-        validateAuthNumber(email, request.authNumber(), authFailCount);
-
-        deleteAuthNumber(email);
-
-        return generateTemporaryToken(email);
-    }
-
-    private String loadAuthTemplate(String authNumber) {
-        try {
-            ClassPathResource resource = new ClassPathResource("templates/email-auth-template.html");
-            String template = new String(resource.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
-            return template.replace("{{authNumber}}", authNumber);
-        } catch (Exception e) {
-            throw new RuntimeException("템플릿을 가져올 수 없습니다.", e);
-        }
-    }
-
-    private void generateEmailAttemptsRedisData(String email) {
-        emailAuthRedisRepository.save(email, INITIAL_SEND_COUNT, INITIAL_FAIL_COUNT, emailAuthExpiration);
-    }
-
-    private void initEmailAttemptsIfAbsent(String email) {
-        if (emailAuthRedisRepository.get(email) == null) {
-            generateEmailAttemptsRedisData(email);
-        }
-    }
-
-    private void validateSendCount(EmailAuthMeta emailAuthMeta) {
-        if (emailAuthMeta.sendCount() >= maxSendCount) {
-            throw new TooManyRequestsException("일일 이메일 인증 횟수를 초과하였습니다.");
-        }
-    }
-
-    private void validateAuthFailCount(EmailAuthMeta emailAuthMeta) {
-        if (emailAuthMeta.authFailCount() >= maxAuthAttemptCount) {
-            throw new TooManyRequestsException("일일 이메일 인증 횟수를 초과하였습니다.");
-        }
-    }
-
-    private void validateCanSendEmail(String email) {
-        EmailAuthMeta emailAuthMeta = getEmailAuthMeta(email);
-
-        validateSendCount(emailAuthMeta);
-        validateAuthFailCount(emailAuthMeta);
-    }
-
-    private void increaseSendCount(String email) {
-        emailAuthRedisRepository.increaseSendCount(email);
-    }
-
-    private String generateAndSaveAuthNumber(String email) {
-        String authNumber = RandomUtils.generateRandomNumberString(CODE_LENGTH);
-        authNumberRedisRepository.save(email, authNumber, authNumberExpiration);
-        return authNumber;
-    }
-
-    private EmailAuthMeta validateIsSentEmail(String email) {
-        EmailAuthMeta emailAuthMeta = getEmailAuthMeta(email);
-
-        if (emailAuthMeta == null) {
-            throw new NotFoundException("이메일 인증 요청을 먼저 진행해야 합니다.");
-        }
-
-        return emailAuthMeta;
-    }
-
-    private int validateAndGetAuthFailCount(EmailAuthMeta emailAuthMeta) {
-        int authFailCount = emailAuthMeta.authFailCount();
-
-        if (authFailCount >= maxAuthAttemptCount) {
-            throw new TooManyRequestsException("일일 이메일 인증 횟수를 초과하였습니다.");
-        }
-        return authFailCount;
-    }
-
-    private EmailAuthMeta getEmailAuthMeta(String email) {
-        return emailAuthRedisRepository.get(email);
-    }
-
-    private void validateEmailIsExistByPurpose(String email, EmailAuthPurpose purpose) {
-        if (purpose.equals(FORGOT_PASSWORD)) {
-            memberService.validateEmailIsExistForPasswordReset(email, LOCAL.name());
-        } else {
-            memberService.validateEmailIsExist(email, LOCAL.name());
-        }
-    }
-
-    private void validateAuthNumber(String email, String authNumber, int authFailCount) {
-        String savedAuthNumber = authNumberRedisRepository.get(email)
-                .orElseThrow(() -> new NotFoundException("인증 유효 시간이 만료되었거나, 잘못된 인증 요청입니다."));
-
-        if (!savedAuthNumber.equals(authNumber)) {
-            int increasedAuthFailCount = increaseAuthFailCount(email);
-            throw new InvalidEmailCodeException(increasedAuthFailCount);
-        }
-    }
-
-    private int increaseAuthFailCount(String email) {
-        return emailAuthRedisRepository.increaseAuthFailCount(email);
-    }
-
-    private void deleteAuthNumber(String email) {
-        authNumberRedisRepository.delete(email);
-    }
-
-    private EmailAuthResponse generateTemporaryToken(String email) {
-        String temporaryToken = jwtTokenProvider.createTemporaryToken(email);
-        return EmailAuthResponse.of(temporaryToken);
     }
 }

--- a/src/test/java/tosiltosil/backend/module/auth/application/EmailAuthServiceTest.java
+++ b/src/test/java/tosiltosil/backend/module/auth/application/EmailAuthServiceTest.java
@@ -1,4 +1,4 @@
-package tosiltosil.backend.module.email.application;
+package tosiltosil.backend.module.auth.application;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -8,12 +8,12 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import tosiltosil.backend.common.domain.exception.*;
 import tosiltosil.backend.module.auth.infrastructure.TemporaryTokenRedisRepository;
-import tosiltosil.backend.module.email.domain.EmailAuthMeta;
-import tosiltosil.backend.module.email.domain.request.EmailAuthRequest;
-import tosiltosil.backend.module.email.domain.request.EmailSendRequest;
-import tosiltosil.backend.module.email.domain.response.EmailAuthResponse;
-import tosiltosil.backend.module.email.infrastructure.AuthNumberRedisRepository;
-import tosiltosil.backend.module.email.infrastructure.EmailAuthRedisRepository;
+import tosiltosil.backend.module.auth.domain.response.email.EmailAuthMeta;
+import tosiltosil.backend.module.auth.domain.request.email.EmailAuthRequest;
+import tosiltosil.backend.module.auth.domain.request.email.EmailSendRequest;
+import tosiltosil.backend.module.auth.domain.response.email.EmailAuthResponse;
+import tosiltosil.backend.module.auth.infrastructure.AuthNumberRedisRepository;
+import tosiltosil.backend.module.auth.infrastructure.EmailAuthRedisRepository;
 import tosiltosil.backend.module.member.application.MemberService;
 import tosiltosil.backend.support.IntegrationTestSupport;
 
@@ -23,14 +23,14 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
-import static tosiltosil.backend.module.email.domain.value.EmailAuthPurpose.FORGOT_PASSWORD;
-import static tosiltosil.backend.module.email.domain.value.EmailAuthPurpose.SIGN_UP;
+import static tosiltosil.backend.module.auth.domain.value.EmailAuthPurpose.FORGOT_PASSWORD;
+import static tosiltosil.backend.module.auth.domain.value.EmailAuthPurpose.SIGN_UP;
 
 @SuppressWarnings("NonAsciiCharacters")
-class EmailServiceTest extends IntegrationTestSupport {
+class EmailAuthServiceTest extends IntegrationTestSupport {
 
     @Autowired
-    private EmailService emailService;
+    private EmailAuthService emailAuthService;
 
     @MockitoBean
     private MemberService memberService;
@@ -73,7 +73,7 @@ class EmailServiceTest extends IntegrationTestSupport {
         emailAuthRedisRepository.save(email, maxSendCount, currentAuthCount, 300L);
 
         // when & then
-        assertThatThrownBy(() -> emailService.sendAuthEmail(request))
+        assertThatThrownBy(() -> emailAuthService.sendAuthEmail(request))
                 .isInstanceOf(TooManyRequestsException.class)
                 .hasMessage("일일 이메일 인증 횟수를 초과하였습니다.");
     }
@@ -87,7 +87,7 @@ class EmailServiceTest extends IntegrationTestSupport {
         emailAuthRedisRepository.save(email, currentSendCount, maxAuthCount, 300L);
 
         // when & then
-        assertThatThrownBy(() -> emailService.sendAuthEmail(request))
+        assertThatThrownBy(() -> emailAuthService.sendAuthEmail(request))
                 .isInstanceOf(TooManyRequestsException.class)
                 .hasMessage("일일 이메일 인증 횟수를 초과하였습니다.");
     }
@@ -102,7 +102,7 @@ class EmailServiceTest extends IntegrationTestSupport {
                 .when(memberService).validateEmailIsExist(anyString(), anyString());
 
         // when & then
-        assertThatThrownBy(() -> emailService.sendAuthEmail(request))
+        assertThatThrownBy(() -> emailAuthService.sendAuthEmail(request))
                 .isInstanceOf(ConflictException.class)
                 .hasMessage("이미 등록된 이메일입니다.");
     }
@@ -115,7 +115,7 @@ class EmailServiceTest extends IntegrationTestSupport {
                 .when(memberService).validateEmailIsExistForPasswordReset(anyString(), anyString());
 
         // when & then
-        assertThatThrownBy(() -> emailService.sendAuthEmail(request))
+        assertThatThrownBy(() -> emailAuthService.sendAuthEmail(request))
                 .isInstanceOf(NotFoundException.class)
                 .hasMessage("등록되지 않은 이메일입니다.");
     }
@@ -132,7 +132,7 @@ class EmailServiceTest extends IntegrationTestSupport {
         authNumberRedisRepository.save(email, authNumber, 300L);
 
         // when
-        EmailAuthResponse response = emailService.verifyAuthEmail(request);
+        EmailAuthResponse response = emailAuthService.verifyAuthEmail(request);
 
         // then
         assertThat(response.temporaryToken()).isNotBlank();
@@ -154,7 +154,7 @@ class EmailServiceTest extends IntegrationTestSupport {
         authNumberRedisRepository.save(email, authNumber, 300L);
 
         // when & then
-        assertThatThrownBy(() -> emailService.verifyAuthEmail(request))
+        assertThatThrownBy(() -> emailAuthService.verifyAuthEmail(request))
                 .isInstanceOf(InvalidEmailCodeException.class)
                 .hasMessage("인증번호를 1회 틀렸습니다. 다시 확인해주세요.");
 
@@ -172,7 +172,7 @@ class EmailServiceTest extends IntegrationTestSupport {
         emailAuthRedisRepository.save(email, currentSendCount, maxAuthCount, 300L);
 
         // when & then
-        assertThatThrownBy(() -> emailService.verifyAuthEmail(request))
+        assertThatThrownBy(() -> emailAuthService.verifyAuthEmail(request))
                 .isInstanceOf(TooManyRequestsException.class)
                 .hasMessage("일일 이메일 인증 횟수를 초과하였습니다.");
     }
@@ -190,7 +190,7 @@ class EmailServiceTest extends IntegrationTestSupport {
         // when & then
         assertThat(authNumberRedisRepository.get(email)).isEmpty();
 
-        assertThatThrownBy(() -> emailService.verifyAuthEmail(request))
+        assertThatThrownBy(() -> emailAuthService.verifyAuthEmail(request))
                 .isInstanceOf(NotFoundException.class)
                 .hasMessage("인증 유효 시간이 만료되었거나, 잘못된 인증 요청입니다.");
     }
@@ -204,7 +204,7 @@ class EmailServiceTest extends IntegrationTestSupport {
         // when & then
         assertThat(authNumberRedisRepository.get(email)).isEmpty();
 
-        assertThatThrownBy(() -> emailService.verifyAuthEmail(request))
+        assertThatThrownBy(() -> emailAuthService.verifyAuthEmail(request))
                 .isInstanceOf(NotFoundException.class)
                 .hasMessage("이메일 인증 요청을 먼저 진행해야 합니다.");
     }

--- a/src/test/java/tosiltosil/backend/module/auth/presentation/EmailAuthControllerRestDocsTest.java
+++ b/src/test/java/tosiltosil/backend/module/auth/presentation/EmailAuthControllerRestDocsTest.java
@@ -1,4 +1,4 @@
-package tosiltosil.backend.module.email.presentation;
+package tosiltosil.backend.module.auth.presentation;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -10,11 +10,11 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.assertj.MvcTestResult;
 import tosiltosil.backend.common.domain.exception.*;
 import tosiltosil.backend.common.util.CookieUtil;
-import tosiltosil.backend.module.email.application.EmailService;
-import tosiltosil.backend.module.email.domain.request.EmailAuthRequest;
-import tosiltosil.backend.module.email.domain.request.EmailSendRequest;
-import tosiltosil.backend.module.email.domain.response.EmailAuthResponse;
-import tosiltosil.backend.module.email.domain.response.EmailSendResponse;
+import tosiltosil.backend.module.auth.application.EmailAuthService;
+import tosiltosil.backend.module.auth.domain.request.email.EmailAuthRequest;
+import tosiltosil.backend.module.auth.domain.request.email.EmailSendRequest;
+import tosiltosil.backend.module.auth.domain.response.email.EmailAuthResponse;
+import tosiltosil.backend.module.auth.domain.response.email.EmailSendResponse;
 import tosiltosil.backend.support.RestDocsTestSupport;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -24,12 +24,12 @@ import static org.springframework.restdocs.cookies.CookieDocumentation.responseC
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 
-@WebMvcTest(EmailController.class)
+@WebMvcTest(EmailAuthController.class)
 @SuppressWarnings("NonAsciiCharacters")
-class EmailControllerRestDocsTest extends RestDocsTestSupport {
+class EmailAuthControllerRestDocsTest extends RestDocsTestSupport {
 
     @MockitoBean
-    private EmailService emailService;
+    private EmailAuthService emailAuthService;
 
     @MockitoBean
     private CookieUtil cookieUtil;
@@ -46,7 +46,7 @@ class EmailControllerRestDocsTest extends RestDocsTestSupport {
 
         EmailSendResponse response = EmailSendResponse.of("test@example.com");
 
-        given(emailService.sendAuthEmail(any(EmailSendRequest.class)))
+        given(emailAuthService.sendAuthEmail(any(EmailSendRequest.class)))
                 .willReturn(response);
 
         // when
@@ -83,7 +83,7 @@ class EmailControllerRestDocsTest extends RestDocsTestSupport {
                 }
                 """;
 
-        given(emailService.sendAuthEmail(any(EmailSendRequest.class)))
+        given(emailAuthService.sendAuthEmail(any(EmailSendRequest.class)))
                 .willThrow(new TooManyRequestsException("일일 이메일 인증 횟수를 초과하였습니다."));
 
         // when
@@ -117,7 +117,7 @@ class EmailControllerRestDocsTest extends RestDocsTestSupport {
                 }
                 """;
 
-        given(emailService.sendAuthEmail(any(EmailSendRequest.class)))
+        given(emailAuthService.sendAuthEmail(any(EmailSendRequest.class)))
                 .willThrow(new BadRequestException("파라미터 값이 잘못되었습니다"));
 
         // when
@@ -157,7 +157,7 @@ class EmailControllerRestDocsTest extends RestDocsTestSupport {
                 }
                 """;
 
-        given(emailService.sendAuthEmail(any(EmailSendRequest.class)))
+        given(emailAuthService.sendAuthEmail(any(EmailSendRequest.class)))
                 .willThrow(new BadRequestException("파라미터 값이 유효하지 않습니다."));
 
         // when
@@ -197,7 +197,7 @@ class EmailControllerRestDocsTest extends RestDocsTestSupport {
                 }
                 """;
 
-        given(emailService.sendAuthEmail(any(EmailSendRequest.class)))
+        given(emailAuthService.sendAuthEmail(any(EmailSendRequest.class)))
                 .willThrow(new NotFoundException("등록되지 않은 이메일입니다."));
 
 
@@ -232,7 +232,7 @@ class EmailControllerRestDocsTest extends RestDocsTestSupport {
                 }
                 """;
 
-        given(emailService.sendAuthEmail(any(EmailSendRequest.class)))
+        given(emailAuthService.sendAuthEmail(any(EmailSendRequest.class)))
                 .willThrow(new ConflictException("이미 등록된 이메일입니다."));
 
 
@@ -269,7 +269,7 @@ class EmailControllerRestDocsTest extends RestDocsTestSupport {
 
         String temporaryToken = "temporary-token"; // 임시 토큰 예시
 
-        given(emailService.verifyAuthEmail(any(EmailAuthRequest.class)))
+        given(emailAuthService.verifyAuthEmail(any(EmailAuthRequest.class)))
                 .willReturn(EmailAuthResponse.of(temporaryToken));
 
         HttpHeaders mockHeaders = new HttpHeaders();
@@ -314,7 +314,7 @@ class EmailControllerRestDocsTest extends RestDocsTestSupport {
                 }
                 """;
 
-        given(emailService.verifyAuthEmail(any(EmailAuthRequest.class)))
+        given(emailAuthService.verifyAuthEmail(any(EmailAuthRequest.class)))
                 .willThrow(new TooManyRequestsException("일일 이메일 인증 횟수를 초과하였습니다."));
 
         // when
@@ -348,7 +348,7 @@ class EmailControllerRestDocsTest extends RestDocsTestSupport {
                 }
                 """;
 
-        given(emailService.verifyAuthEmail(any(EmailAuthRequest.class)))
+        given(emailAuthService.verifyAuthEmail(any(EmailAuthRequest.class)))
                 .willThrow(new BadRequestException("파라미터 값이 잘못되었습니다"));
 
         // when
@@ -391,7 +391,7 @@ class EmailControllerRestDocsTest extends RestDocsTestSupport {
 
         int currentFailCount = 1;
 
-        given(emailService.verifyAuthEmail(any(EmailAuthRequest.class)))
+        given(emailAuthService.verifyAuthEmail(any(EmailAuthRequest.class)))
                 .willThrow(new InvalidEmailCodeException(currentFailCount));
 
         // when
@@ -425,7 +425,7 @@ class EmailControllerRestDocsTest extends RestDocsTestSupport {
                 }
                 """;
 
-        given(emailService.verifyAuthEmail(any(EmailAuthRequest.class)))
+        given(emailAuthService.verifyAuthEmail(any(EmailAuthRequest.class)))
                 .willThrow(new NotFoundException("인증 유효 시간이 만료되었거나, 잘못된 인증 요청입니다."));
 
         // when
@@ -459,7 +459,7 @@ class EmailControllerRestDocsTest extends RestDocsTestSupport {
                 }
                 """;
 
-        given(emailService.verifyAuthEmail(any(EmailAuthRequest.class)))
+        given(emailAuthService.verifyAuthEmail(any(EmailAuthRequest.class)))
                 .willThrow(new NotFoundException("이메일 인증 요청을 먼저 진행해야 합니다."));
 
         // when


### PR DESCRIPTION
## 🔢 Issue Number
close #91 
<!-- close #{issue-number} when solved issue -->
<!-- relates to #{issue-number} when just link without closing -->

## 👨‍💻 작업 내용
이전에 작성했던 코드에서 이메일 인증 로직이 `EmailService` 에 포함되어, 너무 많은 책임을 갖게 된다는 문제점이 있었습니다.

`EmailService` 는 이메일은 전송하는 역할만 부여하고, 이메일 인증 로직은 `EmailAuthService` 로 옮겨 작성하였습니다.

또한 이메일 인증과 관련된 모든 파일들을 `Auth` 폴더 하단으로 옮겼습니다.

<!-- 회원 비밀번호 저장 암호화 알고리즘을 수정했습니다. --> 

## 🤔 고민할 점
이전에 조언해주셨던 DDD 적용은 리팩토링 과정에서 꼭 해보겠습니다....!!!!
<!-- ERD 설계에서 어떻게 해야할 지 모르겠습니다. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 이메일 인증 코드 발송/검증 기능 추가(HTML 템플릿 메일, 6자리 코드, 일일 발송/인증 시도 제한, 만료/오입력 처리).
  - 인증 성공 시 임시 토큰 발급.
- 리팩터
  - 이메일 인증 관련 도메인과 컨트롤러를 auth 모듈로 이관 및 명칭 정리.
  - 요청/응답 타입 패키지 구조 재정비.
- 테스트
  - 컨트롤러/서비스 테스트를 신규 구조로 마이그레이션하고 시나리오(발송, 검증, 예외) 검증 유지.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->