### PR TITLE
[#77] 카테고리 삭제 로직 리팩토링과 리포지토리 네이밍 개선

### DIFF
--- a/src/main/java/tosiltosil/backend/module/goal/application/GoalEventHandler.java
+++ b/src/main/java/tosiltosil/backend/module/goal/application/GoalEventHandler.java
@@ -27,8 +27,6 @@ public class GoalEventHandler {
 
         // 목표 완료되었는지 체크 및 반영
         goal.changeStatusToCompleted();
-
-        // TODO: duration 추가
     }
     
     @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)

--- a/src/main/java/tosiltosil/backend/module/goal/application/GoalEventHandler.java
+++ b/src/main/java/tosiltosil/backend/module/goal/application/GoalEventHandler.java
@@ -27,6 +27,8 @@ public class GoalEventHandler {
 
         // 목표 완료되었는지 체크 및 반영
         goal.changeStatusToCompleted();
+
+        // TODO: duration 추가
     }
     
     @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)

--- a/src/main/java/tosiltosil/backend/module/progress/application/ProgressEventHandler.java
+++ b/src/main/java/tosiltosil/backend/module/progress/application/ProgressEventHandler.java
@@ -1,4 +1,4 @@
-package tosiltosil.backend.module.duration.application;
+package tosiltosil.backend.module.progress.application;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -9,18 +9,17 @@ import tosiltosil.backend.module.goal.domain.event.GoalDeletedEvent;
 
 @Component
 @RequiredArgsConstructor
-public class DurationEventHandler {
+public class ProgressEventHandler {
 
-    private final DurationService durationService;
+    private final ProgressService progressService;
 
-    // TODO: Transaction 구성 고민
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleCategoryDeletedEvent(final CategoryDeletedEvent event) {
-        durationService.subtractTodayDuration(event.memberId(), event.deletedTotalDuration());
+        progressService.subtractTodayDuration(event.memberId(), event.deletedTotalDuration());
     }
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleGoalDeletedEvent(final GoalDeletedEvent event) {
-        durationService.subtractTodayDuration(event.memberId(), event.deletedDuration());
+        progressService.subtractTodayDuration(event.memberId(), event.deletedDuration());
     }
 }

--- a/src/main/java/tosiltosil/backend/module/progress/application/ProgressService.java
+++ b/src/main/java/tosiltosil/backend/module/progress/application/ProgressService.java
@@ -1,35 +1,35 @@
-package tosiltosil.backend.module.duration.application;
+package tosiltosil.backend.module.progress.application;
 
 import java.time.Duration;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import tosiltosil.backend.module.duration.infrastructure.DurationRedisRepository;
+import tosiltosil.backend.module.progress.infrastructure.ProgressRedisRepository;
 
 @Service
 @RequiredArgsConstructor
-public class DurationService {
+public class ProgressService {
 
-    private final DurationRedisRepository durationRedisRepository;
+    private final ProgressRedisRepository progressRedisRepository;
 
     public Duration getTodayDuration(final UUID memberId) {
-        return durationRedisRepository.findTodayDuration(memberId);
+        return progressRedisRepository.findTodayDuration(memberId);
     }
 
     public Duration updateTodayDuration(final UUID memberId, final Duration duration) {
-        Duration todayTotalTime = durationRedisRepository.findTodayDuration(memberId);
+        Duration todayTotalTime = progressRedisRepository.findTodayDuration(memberId);
         todayTotalTime = todayTotalTime.plus(duration);
-        durationRedisRepository.cacheTodayDuration(memberId, todayTotalTime);
+        progressRedisRepository.cacheTodayDuration(memberId, todayTotalTime);
         return todayTotalTime;
     }
     
     public Duration subtractTodayDuration(final UUID memberId, final Duration duration) {
-        Duration todayTotalTime = durationRedisRepository.findTodayDuration(memberId);
+        Duration todayTotalTime = progressRedisRepository.findTodayDuration(memberId);
         todayTotalTime = todayTotalTime.minus(duration);
         if (todayTotalTime.isNegative()) {
             todayTotalTime = Duration.ZERO;
         }
-        durationRedisRepository.cacheTodayDuration(memberId, todayTotalTime);
+        progressRedisRepository.cacheTodayDuration(memberId, todayTotalTime);
         return todayTotalTime;
     }
 }

--- a/src/main/java/tosiltosil/backend/module/progress/application/ProgressService.java
+++ b/src/main/java/tosiltosil/backend/module/progress/application/ProgressService.java
@@ -21,7 +21,7 @@ public class ProgressService {
         return progressRepository.findTodayDurationByMemberId(memberId);
     }
 
-    @Transactional(readOnly = true)
+    @Transactional
     public Duration updateTodayDuration(final UUID memberId, final Duration duration) {
         Optional<Progress> progressOptional = progressRepository.findByMemberId(memberId);
         Progress progress = progressOptional.orElseGet(() -> {
@@ -35,7 +35,7 @@ public class ProgressService {
         return progress.getTodayDuration();
     }
 
-    @Transactional(readOnly = true)
+    @Transactional
     public Duration subtractTodayDuration(final UUID memberId, final Duration duration) {
         Optional<Progress> progressOptional = progressRepository.findByMemberId(memberId);
         Progress progress = progressOptional.orElseGet(() -> {

--- a/src/main/java/tosiltosil/backend/module/progress/application/ProgressService.java
+++ b/src/main/java/tosiltosil/backend/module/progress/application/ProgressService.java
@@ -4,32 +4,40 @@ import java.time.Duration;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import tosiltosil.backend.module.progress.infrastructure.ProgressRedisRepository;
+import org.springframework.transaction.annotation.Transactional;
+import tosiltosil.backend.module.progress.domain.Progress;
+import tosiltosil.backend.module.progress.domain.ProgressRepository;
 
 @Service
 @RequiredArgsConstructor
 public class ProgressService {
 
-    private final ProgressRedisRepository progressRedisRepository;
+    private final ProgressRepository progressRepository;
 
+    @Transactional(readOnly = true)
     public Duration getTodayDuration(final UUID memberId) {
-        return progressRedisRepository.findTodayDuration(memberId);
+        return progressRepository.findTodayDurationByMemberId(memberId);
     }
 
+    @Transactional(readOnly = true)
     public Duration updateTodayDuration(final UUID memberId, final Duration duration) {
-        Duration todayTotalTime = progressRedisRepository.findTodayDuration(memberId);
-        todayTotalTime = todayTotalTime.plus(duration);
-        progressRedisRepository.cacheTodayDuration(memberId, todayTotalTime);
-        return todayTotalTime;
+        // TODO: empty일 경우 처리
+        Progress progress = progressRepository.findByMemberId(memberId).get();
+
+        progress.addTodayDuration(duration);
+        progressRepository.save(progress);
+
+        return progress.getTodayDuration();
     }
-    
+
+    @Transactional(readOnly = true)
     public Duration subtractTodayDuration(final UUID memberId, final Duration duration) {
-        Duration todayTotalTime = progressRedisRepository.findTodayDuration(memberId);
-        todayTotalTime = todayTotalTime.minus(duration);
-        if (todayTotalTime.isNegative()) {
-            todayTotalTime = Duration.ZERO;
-        }
-        progressRedisRepository.cacheTodayDuration(memberId, todayTotalTime);
-        return todayTotalTime;
+        // TODO: empty일 경우 처리
+        Progress progress = progressRepository.findByMemberId(memberId).get();
+
+        progress.subtractTodayDuration(duration);
+        progressRepository.save(progress);
+
+        return progress.getTodayDuration();
     }
 }

--- a/src/main/java/tosiltosil/backend/module/progress/application/ProgressService.java
+++ b/src/main/java/tosiltosil/backend/module/progress/application/ProgressService.java
@@ -1,10 +1,12 @@
 package tosiltosil.backend.module.progress.application;
 
 import java.time.Duration;
+import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import tosiltosil.backend.common.logging.domain.InfoLog;
 import tosiltosil.backend.module.progress.domain.Progress;
 import tosiltosil.backend.module.progress.domain.ProgressRepository;
 
@@ -21,8 +23,11 @@ public class ProgressService {
 
     @Transactional(readOnly = true)
     public Duration updateTodayDuration(final UUID memberId, final Duration duration) {
-        // TODO: empty일 경우 처리
-        Progress progress = progressRepository.findByMemberId(memberId).get();
+        Optional<Progress> progressOptional = progressRepository.findByMemberId(memberId);
+        Progress progress = progressOptional.orElseGet(() -> {
+            InfoLog.of("계정 생성 시 Progress가 생성되지 않아 지금 생성합니다. 계정 생성 부분을 확인해주세요");
+            return Progress.of(memberId, Duration.ZERO, 0);
+        });
 
         progress.addTodayDuration(duration);
         progressRepository.save(progress);
@@ -32,8 +37,11 @@ public class ProgressService {
 
     @Transactional(readOnly = true)
     public Duration subtractTodayDuration(final UUID memberId, final Duration duration) {
-        // TODO: empty일 경우 처리
-        Progress progress = progressRepository.findByMemberId(memberId).get();
+        Optional<Progress> progressOptional = progressRepository.findByMemberId(memberId);
+        Progress progress = progressOptional.orElseGet(() -> {
+            InfoLog.of("계정 생성 시 Progress가 생성되지 않아 지금 생성합니다. 계정 생성 부분을 확인해주세요");
+            return Progress.of(memberId, Duration.ZERO, 0);
+        });
 
         progress.subtractTodayDuration(duration);
         progressRepository.save(progress);

--- a/src/main/java/tosiltosil/backend/module/progress/domain/Progress.java
+++ b/src/main/java/tosiltosil/backend/module/progress/domain/Progress.java
@@ -16,7 +16,7 @@ public class Progress extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, columnDefinition = "BINARY(16)")
+    @Column(nullable = false, unique = true, columnDefinition = "BINARY(16)")
     private UUID memberId;
 
     @Transient
@@ -33,7 +33,7 @@ public class Progress extends BaseEntity {
             final int totalGoalAchievedCount
     ) {
         this.memberId = memberId;
-        this.todayDuration = todayDuration;
+        this.todayDuration = (todayDuration == null) ? Duration.ZERO : todayDuration;
         this.totalGoalAchievedCount = totalGoalAchievedCount;
     }
 

--- a/src/main/java/tosiltosil/backend/module/progress/domain/Progress.java
+++ b/src/main/java/tosiltosil/backend/module/progress/domain/Progress.java
@@ -1,0 +1,64 @@
+package tosiltosil.backend.module.progress.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import tosiltosil.backend.common.domain.BaseEntity;
+
+import java.time.Duration;
+import java.util.UUID;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Progress extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, columnDefinition = "BINARY(16)")
+    private UUID memberId;
+
+    @Transient
+    @Setter // for mapping
+    private Duration todayDuration;
+
+    @Column(nullable = false)
+    private int totalGoalAchievedCount;
+
+    @Builder
+    private Progress(
+            final UUID memberId,
+            final Duration todayDuration,
+            final int totalGoalAchievedCount
+    ) {
+        this.memberId = memberId;
+        this.todayDuration = todayDuration;
+        this.totalGoalAchievedCount = totalGoalAchievedCount;
+    }
+
+    public static Progress of(
+            final UUID memberId,
+            final Duration todayDuration,
+            final int totalGoalAchievedCount
+    ) {
+        return Progress.builder()
+                .memberId(memberId)
+                .todayDuration(todayDuration)
+                .totalGoalAchievedCount(totalGoalAchievedCount)
+                .build();
+    }
+
+    public void addTodayDuration(final Duration duration) {
+        this.todayDuration = this.todayDuration.plus(duration);
+    }
+
+    public void subtractTodayDuration(final Duration duration) {
+        Duration totalTime = this.todayDuration.minus(duration);
+        if (totalTime.isNegative()) {
+            this.todayDuration = Duration.ZERO;
+        } else {
+            this.todayDuration = totalTime;
+        }
+    }
+}

--- a/src/main/java/tosiltosil/backend/module/progress/domain/ProgressRepository.java
+++ b/src/main/java/tosiltosil/backend/module/progress/domain/ProgressRepository.java
@@ -1,0 +1,16 @@
+package tosiltosil.backend.module.progress.domain;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface ProgressRepository {
+
+    Optional<Progress> findByMemberId(UUID memberId);
+
+    void save(Progress progress);
+
+    Duration findTodayDurationByMemberId(UUID memberId);
+
+    void saveTodayDuration(UUID memberId, Duration duration);
+}

--- a/src/main/java/tosiltosil/backend/module/progress/infrastructure/ProgressJpaRepository.java
+++ b/src/main/java/tosiltosil/backend/module/progress/infrastructure/ProgressJpaRepository.java
@@ -1,0 +1,12 @@
+package tosiltosil.backend.module.progress.infrastructure;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import tosiltosil.backend.module.progress.domain.Progress;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface ProgressJpaRepository extends JpaRepository<Progress, Long> {
+
+    Optional<Progress> findByMemberId(UUID memberId);
+}

--- a/src/main/java/tosiltosil/backend/module/progress/infrastructure/ProgressRedisRepository.java
+++ b/src/main/java/tosiltosil/backend/module/progress/infrastructure/ProgressRedisRepository.java
@@ -1,4 +1,4 @@
-package tosiltosil.backend.module.duration.infrastructure;
+package tosiltosil.backend.module.progress.infrastructure;
 
 import java.time.Duration;
 import java.util.UUID;
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class DurationRedisRepository {
+public class ProgressRedisRepository {
 
     private static final String TOTAL_TIME_KEY = "today_total_time:%s";
 

--- a/src/main/java/tosiltosil/backend/module/progress/infrastructure/ProgressRepositoryImpl.java
+++ b/src/main/java/tosiltosil/backend/module/progress/infrastructure/ProgressRepositoryImpl.java
@@ -1,0 +1,43 @@
+package tosiltosil.backend.module.progress.infrastructure;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import tosiltosil.backend.module.progress.domain.Progress;
+import tosiltosil.backend.module.progress.domain.ProgressRepository;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+public class ProgressRepositoryImpl implements ProgressRepository {
+
+    private final ProgressJpaRepository progressJpaRepository;
+    private final ProgressRedisRepository progressRedisRepository;
+
+    @Override
+    public Optional<Progress> findByMemberId(final UUID memberId) {
+        Optional<Progress> progressOptional = progressJpaRepository.findByMemberId(memberId);
+        if (progressOptional.isEmpty()) return progressOptional;
+        Progress progress = progressOptional.get();
+        progress.setTodayDuration(progressRedisRepository.findTodayDuration(memberId));
+        return Optional.of(progress);
+    }
+
+    @Override
+    public void save(final Progress progress) {
+        progressJpaRepository.save(progress);
+        progressRedisRepository.cacheTodayDuration(progress.getMemberId(), progress.getTodayDuration());
+    }
+
+    @Override
+    public Duration findTodayDurationByMemberId(final UUID memberId) {
+        return progressRedisRepository.findTodayDuration(memberId);
+    }
+
+    @Override
+    public void saveTodayDuration(final UUID memberId, final Duration duration) {
+        progressRedisRepository.cacheTodayDuration(memberId, duration);
+    }
+}

--- a/src/main/java/tosiltosil/backend/module/stopwatch/application/StopwatchService.java
+++ b/src/main/java/tosiltosil/backend/module/stopwatch/application/StopwatchService.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import tosiltosil.backend.common.domain.exception.NotFoundException;
 import tosiltosil.backend.common.messaging.Events;
-import tosiltosil.backend.module.duration.application.DurationService;
+import tosiltosil.backend.module.progress.application.ProgressService;
 import tosiltosil.backend.module.goal.application.GoalService;
 import tosiltosil.backend.module.stopwatch.domain.Stopwatch;
 import tosiltosil.backend.module.stopwatch.domain.StopwatchActivity;
@@ -24,7 +24,7 @@ public class StopwatchService {
 
     private final StopwatchRepository stopwatchRepository;
     private final GoalService goalService;
-    private final DurationService durationService;
+    private final ProgressService progressService;
 
     public void startStopwatch(
             final UUID memberId,
@@ -38,7 +38,7 @@ public class StopwatchService {
         stopwatchRepository.save(stopwatch);
 
         // 오늘 총 진행 시간 가져오기 - 방금 시작된 스톱워치 시간은 제외
-        Duration todayDuration = durationService.getTodayDuration(memberId);
+        Duration todayDuration = progressService.getTodayDuration(memberId);
 
         // 사용자 스탑워치 활성 상태로 변경
         StopwatchActivity stopwatchActivity = stopwatchRepository.findStopwatchActivityByMemberId(memberId)
@@ -68,7 +68,7 @@ public class StopwatchService {
         stopwatch.updateEndAt();
 
         // 오늘 총 진행 시간 업데이트
-        Duration updatedTodayDuration = durationService.updateTodayDuration(memberId, stopwatch.getDuration());
+        Duration updatedTodayDuration = progressService.updateTodayDuration(memberId, stopwatch.getDuration());
 
         // 사용자 스탑워치 비활성 상태로 변경
         StopwatchActivity stopwatchActivity = stopwatchRepository.findStopwatchActivityByMemberId(memberId)

--- a/src/test/java/tosiltosil/backend/module/category/application/CategoryServiceTest.java
+++ b/src/test/java/tosiltosil/backend/module/category/application/CategoryServiceTest.java
@@ -26,13 +26,13 @@ import tosiltosil.backend.module.category.domain.value.CategoryColor;
 import tosiltosil.backend.module.category.domain.response.CategoryResponse;
 import tosiltosil.backend.module.category.domain.response.CurrentCategoryListResponse;
 import tosiltosil.backend.module.category.infrastructure.CategoryJpaRepository;
-import tosiltosil.backend.module.duration.application.DurationService;
 import tosiltosil.backend.module.goal.application.GoalService;
 import tosiltosil.backend.module.goal.domain.Goal;
 import tosiltosil.backend.module.goal.domain.GoalRepository;
 import tosiltosil.backend.module.goal.domain.request.GoalCreateRequest;
 import tosiltosil.backend.module.goal.domain.response.GoalIdsResponse;
 import tosiltosil.backend.module.goal.infrastructure.GoalJpaRepository;
+import tosiltosil.backend.module.progress.application.ProgressService;
 import tosiltosil.backend.support.IntegrationTestSupport;
 
 @Import(TestTimeHolderConfig.class)
@@ -49,7 +49,7 @@ class CategoryServiceTest extends IntegrationTestSupport {
     private GoalRepository goalRepository;
 
     @Autowired
-    private DurationService durationService;
+    private ProgressService progressService;
 
     @Autowired
     private RedisTemplate<String, Object> redisTemplate;
@@ -205,13 +205,13 @@ class CategoryServiceTest extends IntegrationTestSupport {
         goalRepository.save(goal);
 
         // 4. 총 기록시간에 30분 추가
-        durationService.updateTodayDuration(memberId, testDuration);
+        progressService.updateTodayDuration(memberId, testDuration);
         
         // when
         categoryService.deleteCategory(memberId, category.categoryId());
         
         // then
-        Duration afterDelete = durationService.getTodayDuration(memberId);
+        Duration afterDelete = progressService.getTodayDuration(memberId);
         assertThat(afterDelete).isEqualTo(Duration.ZERO);
 
         // verify

--- a/src/test/java/tosiltosil/backend/module/progress/application/TodayProgressServiceTest.java
+++ b/src/test/java/tosiltosil/backend/module/progress/application/TodayProgressServiceTest.java
@@ -34,9 +34,10 @@ class TodayProgressServiceTest {
         when(progressRedisRepository.findTodayDuration(memberId)).thenReturn(currentDuration);
 
         // when
-        Duration result = progressService.updateTodayDuration(memberId, additionalDuration);
+        progressService.updateTodayDuration(memberId, additionalDuration);
 
         // then
+        Duration result = progressService.getTodayDuration(memberId);
         assertThat(result).isEqualTo(expectedTotalDuration);
     }
 

--- a/src/test/java/tosiltosil/backend/module/progress/application/TodayProgressServiceTest.java
+++ b/src/test/java/tosiltosil/backend/module/progress/application/TodayProgressServiceTest.java
@@ -1,24 +1,25 @@
 package tosiltosil.backend.module.progress.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.time.Duration;
+import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import tosiltosil.backend.module.progress.infrastructure.ProgressRedisRepository;
+import tosiltosil.backend.module.progress.domain.Progress;
+import tosiltosil.backend.module.progress.domain.ProgressRepository;
 
 @ExtendWith(MockitoExtension.class)
 @SuppressWarnings("NonAsciiCharacters")
 class TodayProgressServiceTest {
 
     @Mock
-    private ProgressRedisRepository progressRedisRepository;
+    private ProgressRepository progressRepository;
 
     @InjectMocks
     private ProgressService progressService;
@@ -28,16 +29,16 @@ class TodayProgressServiceTest {
         // given
         UUID memberId = UUID.randomUUID();
         Duration currentDuration = Duration.ofHours(3);
+        Progress progress = Progress.of(memberId, currentDuration, 0);
         Duration additionalDuration = Duration.ofHours(2);
         Duration expectedTotalDuration = Duration.ofHours(5);
-        
-        when(progressRedisRepository.findTodayDuration(memberId)).thenReturn(currentDuration);
+
+        when(progressRepository.findByMemberId(memberId)).thenReturn(Optional.ofNullable(progress));
 
         // when
-        progressService.updateTodayDuration(memberId, additionalDuration);
+        Duration result = progressService.updateTodayDuration(memberId, additionalDuration);
 
         // then
-        Duration result = progressService.getTodayDuration(memberId);
         assertThat(result).isEqualTo(expectedTotalDuration);
     }
 
@@ -46,10 +47,11 @@ class TodayProgressServiceTest {
         // given
         UUID memberId = UUID.randomUUID();
         Duration currentDuration = Duration.ZERO;
+        Progress progress = Progress.of(memberId, currentDuration, 0);
         Duration additionalDuration = Duration.ofMinutes(30);
         Duration expectedTotalDuration = Duration.ofMinutes(30);
-        
-        when(progressRedisRepository.findTodayDuration(memberId)).thenReturn(currentDuration);
+
+        when(progressRepository.findByMemberId(memberId)).thenReturn(Optional.ofNullable(progress));
 
         // when
         Duration result = progressService.updateTodayDuration(memberId, additionalDuration);
@@ -63,17 +65,17 @@ class TodayProgressServiceTest {
         // given
         UUID memberId = UUID.randomUUID();
         Duration currentDuration = Duration.ofMinutes(30);
+        Progress progress = Progress.of(memberId, currentDuration, 0);
         Duration subtractDuration = Duration.ofHours(2);
         Duration expectedTotalDuration = Duration.ZERO;
-        
-        when(progressRedisRepository.findTodayDuration(memberId)).thenReturn(currentDuration);
+
+        when(progressRepository.findByMemberId(memberId)).thenReturn(Optional.ofNullable(progress));
 
         // when
         Duration result = progressService.subtractTodayDuration(memberId, subtractDuration);
 
         // then
         assertThat(result).isEqualTo(expectedTotalDuration);
-        verify(progressRedisRepository).cacheTodayDuration(memberId, expectedTotalDuration);
     }
     
     @Test
@@ -81,16 +83,16 @@ class TodayProgressServiceTest {
         // given
         UUID memberId = UUID.randomUUID();
         Duration currentDuration = Duration.ZERO;
+        Progress progress = Progress.of(memberId, currentDuration, 0);
         Duration subtractDuration = Duration.ofMinutes(30);
         Duration expectedTotalDuration = Duration.ZERO;
-        
-        when(progressRedisRepository.findTodayDuration(memberId)).thenReturn(currentDuration);
+
+        when(progressRepository.findByMemberId(memberId)).thenReturn(Optional.ofNullable(progress));
 
         // when
         Duration result = progressService.subtractTodayDuration(memberId, subtractDuration);
 
         // then
         assertThat(result).isEqualTo(expectedTotalDuration);
-        verify(progressRedisRepository).cacheTodayDuration(memberId, expectedTotalDuration);
     }
 }

--- a/src/test/java/tosiltosil/backend/module/progress/application/TodayProgressServiceTest.java
+++ b/src/test/java/tosiltosil/backend/module/progress/application/TodayProgressServiceTest.java
@@ -1,4 +1,4 @@
-package tosiltosil.backend.module.duration.application;
+package tosiltosil.backend.module.progress.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
@@ -11,17 +11,17 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import tosiltosil.backend.module.duration.infrastructure.DurationRedisRepository;
+import tosiltosil.backend.module.progress.infrastructure.ProgressRedisRepository;
 
 @ExtendWith(MockitoExtension.class)
 @SuppressWarnings("NonAsciiCharacters")
-class TodayDurationServiceTest {
+class TodayProgressServiceTest {
 
     @Mock
-    private DurationRedisRepository durationRedisRepository;
+    private ProgressRedisRepository progressRedisRepository;
 
     @InjectMocks
-    private DurationService durationService;
+    private ProgressService progressService;
 
     @Test
     void 사용자의_누적_시간을_업데이트한다() {
@@ -31,10 +31,10 @@ class TodayDurationServiceTest {
         Duration additionalDuration = Duration.ofHours(2);
         Duration expectedTotalDuration = Duration.ofHours(5);
         
-        when(durationRedisRepository.findTodayDuration(memberId)).thenReturn(currentDuration);
+        when(progressRedisRepository.findTodayDuration(memberId)).thenReturn(currentDuration);
 
         // when
-        Duration result = durationService.updateTodayDuration(memberId, additionalDuration);
+        Duration result = progressService.updateTodayDuration(memberId, additionalDuration);
 
         // then
         assertThat(result).isEqualTo(expectedTotalDuration);
@@ -48,10 +48,10 @@ class TodayDurationServiceTest {
         Duration additionalDuration = Duration.ofMinutes(30);
         Duration expectedTotalDuration = Duration.ofMinutes(30);
         
-        when(durationRedisRepository.findTodayDuration(memberId)).thenReturn(currentDuration);
+        when(progressRedisRepository.findTodayDuration(memberId)).thenReturn(currentDuration);
 
         // when
-        Duration result = durationService.updateTodayDuration(memberId, additionalDuration);
+        Duration result = progressService.updateTodayDuration(memberId, additionalDuration);
 
         // then
         assertThat(result).isEqualTo(expectedTotalDuration);
@@ -65,14 +65,14 @@ class TodayDurationServiceTest {
         Duration subtractDuration = Duration.ofHours(2);
         Duration expectedTotalDuration = Duration.ZERO;
         
-        when(durationRedisRepository.findTodayDuration(memberId)).thenReturn(currentDuration);
+        when(progressRedisRepository.findTodayDuration(memberId)).thenReturn(currentDuration);
 
         // when
-        Duration result = durationService.subtractTodayDuration(memberId, subtractDuration);
+        Duration result = progressService.subtractTodayDuration(memberId, subtractDuration);
 
         // then
         assertThat(result).isEqualTo(expectedTotalDuration);
-        verify(durationRedisRepository).cacheTodayDuration(memberId, expectedTotalDuration);
+        verify(progressRedisRepository).cacheTodayDuration(memberId, expectedTotalDuration);
     }
     
     @Test
@@ -83,13 +83,13 @@ class TodayDurationServiceTest {
         Duration subtractDuration = Duration.ofMinutes(30);
         Duration expectedTotalDuration = Duration.ZERO;
         
-        when(durationRedisRepository.findTodayDuration(memberId)).thenReturn(currentDuration);
+        when(progressRedisRepository.findTodayDuration(memberId)).thenReturn(currentDuration);
 
         // when
-        Duration result = durationService.subtractTodayDuration(memberId, subtractDuration);
+        Duration result = progressService.subtractTodayDuration(memberId, subtractDuration);
 
         // then
         assertThat(result).isEqualTo(expectedTotalDuration);
-        verify(durationRedisRepository).cacheTodayDuration(memberId, expectedTotalDuration);
+        verify(progressRedisRepository).cacheTodayDuration(memberId, expectedTotalDuration);
     }
 }

--- a/src/test/java/tosiltosil/backend/module/progress/infrastructure/TodayDurationRedisTest.java
+++ b/src/test/java/tosiltosil/backend/module/progress/infrastructure/TodayDurationRedisTest.java
@@ -1,4 +1,4 @@
-package tosiltosil.backend.module.duration.infrastructure;
+package tosiltosil.backend.module.progress.infrastructure;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -14,7 +14,7 @@ import tosiltosil.backend.support.IntegrationTestSupport;
 public class TodayDurationRedisTest extends IntegrationTestSupport {
 
     @Autowired
-    private DurationRedisRepository durationRedisRepository;
+    private ProgressRedisRepository progressRedisRepository;
     
     @Autowired
     private RedisTemplate<String, Object> redisTemplate;
@@ -30,7 +30,7 @@ public class TodayDurationRedisTest extends IntegrationTestSupport {
         UUID memberId = UUID.randomUUID();
         
         // when
-        Duration result = durationRedisRepository.findTodayDuration(memberId);
+        Duration result = progressRedisRepository.findTodayDuration(memberId);
         
         // then
         assertThat(result).isEqualTo(Duration.ZERO);
@@ -41,10 +41,10 @@ public class TodayDurationRedisTest extends IntegrationTestSupport {
         // given
         UUID memberId = UUID.randomUUID();
         Duration zeroDuration = Duration.ZERO;
-        durationRedisRepository.cacheTodayDuration(memberId, zeroDuration);
+        progressRedisRepository.cacheTodayDuration(memberId, zeroDuration);
         
         // when
-        Duration result = durationRedisRepository.findTodayDuration(memberId);
+        Duration result = progressRedisRepository.findTodayDuration(memberId);
         
         // then
         assertThat(result).isEqualTo(Duration.ZERO);


### PR DESCRIPTION
## 🔢 Issue Number
<!-- close #{issue-number} when solved issue -->
<!-- relates to #{issue-number} when just link without closing -->
close #77 

## 👨‍💻 작업 내용
<!-- 회원 비밀번호 저장 암호화 알고리즘을 수정했습니다. --> 
# 도메인 네이밍 변경
`Duration`에서 `Progress`로 변경.
이후 my page 내 "이룬 목표 갯수"까지 다루기 위해 좀 더 포괄적인 네이밍으로 변경했습니다. 

❓ 이후에 "이룬 목표 갯수" 관련 기능을 추가할 예정입니다.

# 카테고리 삭제 이벤트 로직 개선
최대한 도메인 간 의존도를 낮추려 `deleteCategory` 메서드 내, `카테고리 내 목표의 총 성취 시간 계산` 부분을 `goalEventHandler`에서 처리하도록 하려 했으나, Event를 2번에 걸쳐서 발행할 수 없었습니다. 

그래서 `categoryService`내 `deleteCategory` 메서드 내에서 처리하도록(이전 로직 그대로) 두었습니다.

## 🤔 고민할 점
<!-- ERD 설계에서 어떻게 해야할 지 모르겠습니다. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - ‘Duration’ 기반을 ‘Progress’ 기반으로 전면 전환해 일일 누적 시간 로직을 통합·정리했습니다.
  - JPA와 Redis를 조합한 Progress 저장·캐시 계층을 도입해 오늘의 누적 시간 조회·갱신 신뢰성을 높였습니다.
  - 스톱워치, 카테고리·목표 삭제 등 기존 흐름의 연동을 Progress로 일괄 갱신했습니다.
- New Features
  - Progress 엔티티와 관련 서비스·레포지토리 추가로 도메인 모델이 확장되었습니다.
- Tests
  - 도메인명 변경에 맞춰 단위·통합 테스트를 갱신해 누적 시간 동작을 검증했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->