### PR TITLE
[#75] Goal validation 과정 코드 리팩토링

### DIFF
--- a/src/main/java/tosiltosil/backend/module/goal/domain/Goal.java
+++ b/src/main/java/tosiltosil/backend/module/goal/domain/Goal.java
@@ -18,7 +18,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import tosiltosil.backend.common.domain.BaseEntity;
 import tosiltosil.backend.common.domain.exception.BadRequestException;
-import tosiltosil.backend.common.domain.exception.ConflictException;
 import tosiltosil.backend.common.domain.exception.ForbiddenException;
 import tosiltosil.backend.common.domain.order.Orderable;
 import tosiltosil.backend.module.goal.domain.value.GoalStatus;
@@ -140,46 +139,18 @@ public class Goal extends BaseEntity implements Orderable {
 
     // status
     public void changeStatusToStarted() {
-        validateNotCompleted();
-        validateNotFailed();
-        validateNotRunning();
+        this.status.validateRunning();
         this.status = GoalStatus.RUNNING;
     }
 
     public void changeStatusToPaused() {
-        validateNotCompleted();
-        validateNotFailed();
-        validateNotPaused();
+        this.status.validatePaused();
         this.status = GoalStatus.PAUSED;
     }
 
     public void changeStatusToCompleted() {
         if (this.duration.compareTo(this.totalTime) >= 0) {
             this.status = GoalStatus.COMPLETED;
-        }
-    }
-
-    private void validateNotCompleted() {
-        if (this.status == GoalStatus.COMPLETED) {
-            throw new ConflictException("이미 완료된 목표입니다.");
-        }
-    }
-
-    private void validateNotFailed() {
-        if (this.status == GoalStatus.FAILED) {
-            throw new ConflictException("기간이 지나 실패한 목표입니다.");
-        }
-    }
-
-    private void validateNotRunning() {
-        if (this.status == GoalStatus.RUNNING) {
-            throw new ConflictException("스톱워치가 이미 실행중입니다.");
-        }
-    }
-
-    private void validateNotPaused() {
-        if (this.status == GoalStatus.BEFORE_STARTING || this.status == GoalStatus.PAUSED) {
-            throw new ConflictException("스톱워치가 이미 정지되었습니다.");
         }
     }
 

--- a/src/main/java/tosiltosil/backend/module/goal/domain/value/GoalStatus.java
+++ b/src/main/java/tosiltosil/backend/module/goal/domain/value/GoalStatus.java
@@ -1,6 +1,7 @@
 package tosiltosil.backend.module.goal.domain.value;
 
 import com.fasterxml.jackson.annotation.JsonValue;
+import tosiltosil.backend.common.domain.exception.ConflictException;
 
 public enum GoalStatus {
     BEFORE_STARTING("시작 전"),
@@ -18,5 +19,41 @@ public enum GoalStatus {
     @JsonValue
     public String getKoreanName() {
         return koreanName;
+    }
+
+    public void validateRunning() {
+        validateNotCompleted();
+        validateNotFailed();
+        validateNotRunning();
+    }
+
+    public void validatePaused() {
+        validateNotCompleted();
+        validateNotFailed();
+        validateNotPaused();
+    }
+
+    private void validateNotCompleted() {
+        if (this.equals(GoalStatus.COMPLETED)) {
+            throw new ConflictException("이미 완료된 목표입니다.");
+        }
+    }
+
+    private void validateNotFailed() {
+        if (this.equals(GoalStatus.FAILED)) {
+            throw new ConflictException("기간이 지나 실패한 목표입니다.");
+        }
+    }
+
+    private void validateNotRunning() {
+        if (this.equals(GoalStatus.RUNNING)) {
+            throw new ConflictException("스톱워치가 이미 실행중입니다.");
+        }
+    }
+
+    private void validateNotPaused() {
+        if (this.equals(GoalStatus.BEFORE_STARTING) || this.equals(GoalStatus.PAUSED)) {
+            throw new ConflictException("스톱워치가 이미 정지되었습니다.");
+        }
     }
 }


### PR DESCRIPTION
## 🔢 Issue Number
<!-- close #{issue-number} when solved issue -->
<!-- relates to #{issue-number} when just link without closing -->
close #75 

## 👨‍💻 작업 내용
<!-- 회원 비밀번호 저장 암호화 알고리즘을 수정했습니다. --> 
### 간단한 domain 코드 리팩토링
[리팩토링 언급해주신 comment link](https://github.com/sangcci/tosiltosil/pull/66#discussion_r2242580626)
해당 내용을 반영했습니다.

validation 과정을 Value Object로 위임했습니다. 

그 후 2가지 메서드
- `validateRunning()`
- `validatePaused()`

로 분리했습니다.

## 🤔 고민할 점
<!-- ERD 설계에서 어떻게 해야할 지 모르겠습니다. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 없음
- 버그 수정
  - 목표 실행/일시정지 시 부적절한 상태 전환을 보다 정확히 차단하고 안내 메시지를 명확히 제공합니다.
- 리팩터링
  - 목표 상태 전환 검증 로직을 통합해 일관성을 높이고 중복 검증을 제거했습니다.
  - 예외 메시지를 정비하여 사용자에게 더 이해하기 쉬운 한국어 안내를 제공합니다.
  - 외부에서 보이는 동작과 공개 메서드 시그니처는 변경되지 않았습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->